### PR TITLE
Improve 404 error message with actionable hint

### DIFF
--- a/github/scripts/github_common.py
+++ b/github/scripts/github_common.py
@@ -282,6 +282,7 @@ def handle_api_error(response: requests.Response, context: str = "") -> None:
     elif response.status_code == 404:
         print(f"Error: {context or 'Resource'} not found (404)", file=sys.stderr)
         print(f"Message: {error_msg}", file=sys.stderr)
+        print("Hint: Check that the repository, branch, or path exists and your token has access", file=sys.stderr)
         sys.exit(1)
         
     elif response.status_code == 409:


### PR DESCRIPTION
## Summary

This PR improves the user experience when a 404 error occurs by adding an actionable hint to the error message.

## Changes

Modified `github_common.py` to include a helpful hint when a 404 (Not Found) error is returned from the GitHub API:

```
Hint: Check that the repository, branch, or path exists and your token has access
```

## Motivation

When users encounter a 404 error, it's not always obvious what went wrong. The resource might not exist, or the user's token might lack the necessary permissions to access it. This hint guides users toward the most common causes.

## Testing

This PR was created entirely using the GitHub skill scripts to test the new PR workflow functionality.