### PR TITLE
Resolve Open Question #10: Terms of Service for claude -p sub-agent use

### DIFF
--- a/docs/stateful-agent-design.md
+++ b/docs/stateful-agent-design.md
@@ -1,3 +1,4 @@
+
 # Stateful Agent System: Detailed Design
 
 **Version:** 1.0 (Draft)<br/>
@@ -2240,4 +2241,9 @@ The `.search-index.db` file (if it exists) should be in `.gitignore`.
 
 10. **Terms of Service Question:** — Given the news reported by PC World at https://www.pcworld.com/article/3068842/whats-behind-the-openclaw-ban-wave.html about Anthropic banning some automated use of Claude Code CLI, do Anthropic's consumer terms of service at https://www.anthropic.com/legal/consumer-terms or their Acceptable Use Policy at https://www.anthropic.com/legal/aup prevent using Claude Code CLI as a sub-agent?
 
-    - *Resolution:* TBD
+    - *Resolution:* The design is compliant with Anthropic's Terms of Service. The `spawn_agent` tool invokes the official `claude -p` CLI binary as a subprocess — it does not extract, transfer, or reuse OAuth tokens, and it does not make direct Anthropic API calls. The bridge never touches authentication at all; the Claude Code CLI manages its own auth lifecycle internally. The Consumer ToS prohibition on automated access contains an explicit exception for use cases "where we otherwise explicitly permit it," and Anthropic explicitly permits scripted and automated use of the `claude` CLI — their official documentation demonstrates piping, scripting, and CI/CD pipelines as intended patterns.
+
+      The account bans reported in January–February 2026 targeted a specific and narrow behavior: third-party harnesses (OpenCode, OpenClaw, Cline, Roo Code, etc.) that intercepted Claude's OAuth authentication flow, extracted the subscriber's OAuth token, and used it to make direct Anthropic API calls while forging the HTTP headers that the real Claude Code CLI sends — effectively spoofing the official client to gain flat-rate subscription access at API-level volume. Anthropic's formal prohibition, published February 17–19, 2026, reads: *"Using OAuth tokens obtained through Claude Free, Pro, or Max accounts in any other product, tool, or service — including the Agent SDK — is not permitted."* This design does none of that. The critical distinction is: **calling `claude -p` (the real CLI binary) = allowed; extracting OAuth tokens to use in a third-party API client = banned.**
+
+      The "ordinary, individual usage" language added to Anthropic's February 2026 documentation refers to preventing subscription arbitrage at scale (e.g., multi-tenant bots running overnight autonomous swarms on a flat-rate plan, which would cost $1,000+/month at API prices). It does not apply to a single developer running personal project work from their own machine — which is the intended use case for a Max subscription and the exact scenario this design targets.
+


### PR DESCRIPTION
## Summary

Resolves Open Question #10 in `docs/stateful-agent-design.md`, which asks whether Anthropic's Consumer Terms of Service or Acceptable Use Policy prohibit using the Claude Code CLI (`claude -p`) as a sub-agent.

## Resolution

The design is compliant. The key distinction established in Anthropic's January–February 2026 enforcement actions is:

- **Allowed:** Calling `claude -p` (the real CLI binary) — this is Anthropic's official product, explicitly supported for scripted/automated use
- **Banned:** Extracting OAuth tokens from Claude subscriptions to use in third-party API clients that spoof the Claude Code client identity

The `spawn_agent` tool invokes the real `claude` binary as a subprocess. The bridge never touches OAuth tokens. The CLI manages its own auth internally and sends normal telemetry. This is categorically different from what OpenCode/OpenClaw were doing.

The "ordinary, individual usage" language in the February 2026 docs update targets subscription arbitrage at scale, not personal developer use cases.