### PR TITLE
Resolve OQ#12: relay skill contents (transport + semantic layer split)

### DIFF
--- a/ai-messaging/SKILL.md
+++ b/ai-messaging/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: ai-messaging
+description: >
+  Communicate with the local stateful agent system via the GitHub relay.
+  Use this skill when the user wants to interact with their local machine
+  remotely — reading memory files, running shell commands, or delegating
+  tasks to the local Claude Desktop agent. Triggers include phrases like:
+  "on my local machine", "check my local files", "run this on my home
+  computer", "ask my local Claude", "read my memory files", "what's in
+  my core memory", "what's on my home machine", "run this locally".
+  Requires the github skill for relay transport scripts.
+---
+
+# AI Messaging Skill
+
+This skill enables Claude.ai (web or mobile) to communicate with the local
+stateful agent system running on Fran's home machine. It uses the GitHub relay
+transport protocol (provided by the github skill) to send signed requests to
+the local MCP bridge and receive signed responses.
+
+## Prerequisites
+
+- The **github skill** must be installed (provides `relay_send.py`,
+  `relay_receive.py`, and `relay_common.py` in its `scripts/` directory).
+- Environment variables `GITHUB_TOKEN` and `RELAY_HMAC_SECRET` must be set
+  (available via personal instructions).
+- The relay repository is `fpl9000/claude-relay`.
+
+## When to Use This Skill
+
+Use this skill when the user wants to do something that requires their local
+machine — a Windows 11 system running the MCP bridge server. Common triggers:
+
+- "Read my core memory" / "What's in my memory files?"
+- "Run this on my local machine" / "Check something on my home computer"
+- "Ask my local Claude to..." / "Have Claude Desktop do..."
+- "What's the status of [project] locally?"
+- "Run `git status` on my mcp-bridge repo"
+- Any reference to the local machine, local files, or the stateful agent system
+
+Do NOT use this skill for operations that can be performed directly from
+Claude.ai (e.g., reading GitHub repos via the github skill's existing scripts,
+web searches, or general knowledge questions).
+
+## Operations
+
+The relay supports three operations. Choose the simplest one that can
+accomplish the task.
+
+### memory_query
+
+Read a file from the local Layer 2 memory directory
+(`C:\franl\.claude-agent-memory\`). The MCP bridge handles this directly
+with no LLM inference — it simply reads the file and returns its contents.
+
+**When to use:** The user wants to see the contents of a specific memory
+file (core.md, index.md, or a block).
+
+**Arguments:**
+```json
+{"path": "core.md"}
+```
+
+The `path` is relative to the memory directory. Valid paths include:
+- `core.md` — Identity and active project summary
+- `index.md` — Block index table
+- `blocks/project-mcp-bridge.md` — A specific content block
+- `blocks/episodic-2026-03.md` — A specific episodic log
+
+**Example invocation:**
+```bash
+GITHUB_TOKEN="..." RELAY_HMAC_SECRET="..." uv run scripts/relay_send.py \
+    fpl9000/claude-relay \
+    --direction request \
+    --operation memory_query \
+    --arguments '{"path":"core.md"}'
+```
+
+**Response format:** `result.content` contains the full UTF-8 text of the file.
+If the file does not exist, `result.success` is `false` and `result.error`
+describes the problem.
+
+### shell_command
+
+Execute a shell command on the local machine via Cygwin bash. The MCP bridge
+handles this directly with no LLM inference — it runs the command and returns
+stdout/stderr. This is equivalent to the bridge's `run_command` tool.
+
+**When to use:** The task can be expressed as a single shell command or short
+pipeline and requires no LLM reasoning. Examples: `git status`, `ls -la`,
+`grep -r 'TODO' src/`, `cat some-file.txt`, `wc -l *.go`.
+
+**Arguments:**
+```json
+{
+  "command": "cd /c/franl/git/mcp-bridge && git log --oneline -5",
+  "timeout_seconds": 60
+}
+```
+
+- `command` (required) — The shell command to execute.
+- `timeout_seconds` (optional, default: 120) — Maximum runtime before the
+  command is killed.
+
+**Example invocation:**
+```bash
+GITHUB_TOKEN="..." RELAY_HMAC_SECRET="..." uv run scripts/relay_send.py \
+    fpl9000/claude-relay \
+    --direction request \
+    --operation shell_command \
+    --arguments '{"command":"cd /c/franl/git/mcp-bridge && git log --oneline -5"}'
+```
+
+**Response format:** `result.content` contains the combined stdout+stderr.
+`result.exit_code` contains the process exit code (0 = success).
+`result.timed_out` is `true` if the command exceeded its timeout.
+
+### claude_prompt
+
+Forward a prompt to Claude Desktop for full agent-loop processing. Claude
+Desktop receives the prompt, performs whatever tool calls it deems appropriate
+(reading memory, running commands, spawning sub-agents, writing memory
+updates), and returns its final response.
+
+**When to use:** The task requires LLM reasoning, multi-step tool use, or
+memory writes. Examples:
+- "Summarize today's episodic log and update core.md"
+- "Read the mcp-bridge project block and tell me what the open issues are"
+- "Refactor the error handling in server.go"
+- "Create a new memory block for the dashboard-v2 project"
+
+**Arguments:**
+```json
+{
+  "prompt": "Read the mcp-bridge project block and summarize the current open issues."
+}
+```
+
+- `prompt` (required) — The task prompt for Claude Desktop. Write it as if
+  you were typing directly into Claude Desktop's input field. Be specific
+  and self-contained — Claude Desktop does not have context from the
+  current Claude.ai conversation.
+
+**Example invocation:**
+```bash
+GITHUB_TOKEN="..." RELAY_HMAC_SECRET="..." uv run scripts/relay_send.py \
+    fpl9000/claude-relay \
+    --direction request \
+    --operation claude_prompt \
+    --arguments '{"prompt":"Read the mcp-bridge project block and summarize the current open issues."}'
+```
+
+**Response format:** `result.content` contains Claude Desktop's final text
+response. This may be lengthy if the task involved analysis or summarization.
+
+## Decision Tree
+
+When the user asks you to do something on their local machine, choose the
+operation using this decision tree:
+
+1. **Is the user asking to read a specific memory file?**
+   → Use `memory_query`. This is instant (no inference) and costs nothing.
+
+2. **Can the task be expressed as a single shell command?**
+   → Use `shell_command`. Fast, cheap, no inference involved.
+
+3. **Does the task require LLM reasoning, multi-step actions, or memory writes?**
+   → Use `claude_prompt`. This is the most capable but slowest option.
+
+When in doubt, prefer the simpler operation. You can always escalate — for
+example, if a `memory_query` reveals that you need to read multiple files
+and synthesize them, follow up with a `claude_prompt`.
+
+## End-to-End Workflow
+
+Here is the complete sequence for a typical relay interaction:
+
+1. **User asks:** "What are my active projects on my local machine?"
+
+2. **Choose operation:** This is a memory file read → `memory_query` for `core.md`.
+
+3. **Send the request:**
+   ```bash
+   export GITHUB_TOKEN="..."
+   export RELAY_HMAC_SECRET="..."
+   ID=$(uv run scripts/relay_send.py fpl9000/claude-relay \
+       --direction request \
+       --operation memory_query \
+       --arguments '{"path":"core.md"}')
+   ```
+
+4. **Inform the user:** "I've sent a request to your local machine to read
+   your core memory file. I'll check for a response in about 2 minutes."
+
+5. **Poll for the response** (after minimum interval):
+   ```bash
+   uv run scripts/relay_receive.py fpl9000/claude-relay \
+       --direction response \
+       --id "$ID"
+   ```
+
+6. **Handle the result:**
+   - If exit code 0: Parse the verified response and present the content
+     to the user naturally.
+   - If exit code 1 (not found): Wait longer, then poll again (with backoff).
+   - If exit code 2 (HMAC failed): Alert the user to a potential security issue.
+   - If max attempts reached: Inform the user their machine may be offline.
+
+7. **Present the answer:** Summarize the core.md contents in response to
+   the user's question.
+
+## Important Notes
+
+- **The local machine must be running.** The MCP bridge polls the relay repo
+  periodically (default: every 15 seconds). If the machine is off, sleeping,
+  or the bridge is not running, requests will go unanswered.
+
+- **Latency is inherent.** Round-trip times of 1–5 minutes are normal for
+  bridge-local operations; `claude_prompt` may take 5–15 minutes depending
+  on task complexity. Set expectations with the user.
+
+- **Prompts for `claude_prompt` must be self-contained.** Claude Desktop
+  does not have access to the current Claude.ai conversation. Include all
+  necessary context in the prompt itself.
+
+- **HMAC failures are serious.** If `relay_receive.py` reports an HMAC
+  verification failure, do not use the response content. Report the issue
+  to the user.
+
+- **One request at a time.** Do not send multiple relay requests
+  simultaneously. Wait for each response (or timeout) before sending
+  the next request. This simplifies the interaction and avoids overwhelming
+  the bridge's polling loop.

--- a/docs/stateful-agent-design.md
+++ b/docs/stateful-agent-design.md
@@ -2682,6 +2682,457 @@ Design considerations include: handling the case where Claude Desktop is mid-con
 
 If the bridge gains Streamable HTTP transport and a Cloudflare Tunnel (Section 9.3), Claude.ai could potentially connect directly — bypassing the GitHub relay entirely. The relay is the pragmatic v1 solution that works within Claude.ai's current egress restrictions. The two approaches are complementary: the relay can remain as a fallback for environments where tunnel setup is impractical.
 
+#### 9.5.10 Relay Script Inventory
+
+Three new scripts are added to the github skill's `scripts/` directory. All use PEP 723 inline metadata and run via `uv run`.
+
+**`relay_common.py`** — Shared module providing `compute_hmac()`, `canonical_json()`, `generate_message_id()`, and `validate_timestamp()`. Imported by both `relay_send.py` and `relay_receive.py`. Not invoked directly.
+
+**`relay_send.py`** — Constructs a signed relay message and pushes it to the relay repo via the GitHub API.
+
+```
+Usage:
+  uv run scripts/relay_send.py <repo> --direction request|response [options]
+
+  For requests (Claude.ai → bridge):
+    --id <id>                   Message ID (auto-generated if omitted)
+    --operation <op>            Operation name (required)
+    --arguments <json>          JSON object of operation arguments (required)
+    --context <text>            Optional human-readable context (not included in HMAC)
+
+  For responses (bridge → Claude.ai):
+    --id <id>                   Message ID (required, must match the request)
+    --status completed|failed   Response status (required)
+    --result <json>             JSON object of response payload (required)
+
+Environment variables:
+    GITHUB_TOKEN                GitHub PAT with repo access
+    RELAY_HMAC_SECRET           Hex-encoded shared HMAC key
+
+Output:
+    On success, prints the message ID to stdout.
+    On failure, prints an error message to stderr and exits with code 1.
+```
+
+**`relay_receive.py`** — Fetches a relay message from the relay repo, verifies its HMAC signature and timestamp, and returns the validated payload.
+
+```
+Usage:
+  uv run scripts/relay_receive.py <repo> --direction request|response --id <id>
+
+Environment variables:
+    GITHUB_TOKEN                GitHub PAT with repo access
+    RELAY_HMAC_SECRET           Hex-encoded shared HMAC key
+
+Output (JSON to stdout):
+    On success:  {"verified": true, "message": {...}}
+    On HMAC failure: {"error": "HMAC verification failed", "id": "<id>"}  (exit code 2)
+    On timestamp rejection: {"error": "Timestamp rejected: ...", "id": "<id>"}  (exit code 3)
+    On not found: {"error": "Message not found", "id": "<id>"}  (exit code 1)
+```
+
+#### 9.5.11 GitHub Skill Relay Transport Additions
+
+The following section is appended to the existing `github/SKILL.md` when the relay is implemented. It covers the transport protocol only — the semantic layer (operations, decision tree) is in the ai-messaging skill ([Section 9.5.12](#9512-ai-messaging-skill)).
+
+````markdown
+---
+
+## Relay Transport Protocol
+
+The GitHub skill includes scripts for a relay transport protocol that uses a private
+GitHub repository as an asynchronous message bus. This protocol enables communication
+between Claude.ai (which has restricted network egress) and a local MCP bridge server
+(which can read/write to GitHub via the API).
+
+The transport layer is operation-agnostic — it handles message signing, delivery,
+polling, and verification without interpreting the message payload. The semantic
+meaning of operations is defined by the AI Messaging skill, which depends on
+these scripts.
+
+### Prerequisites
+
+In addition to the standard `GITHUB_TOKEN`, the relay scripts require:
+
+- `RELAY_HMAC_SECRET` — A hex-encoded shared secret key for HMAC-SHA256 message
+  authentication. Both Claude.ai and the local MCP bridge must use the same key.
+
+### Message Format
+
+Each relay exchange consists of a request/response pair sharing a unique message ID.
+
+**Request** (pushed to `requests/<id>.json` in the relay repo):
+
+```json
+{
+  "id": "20260307T143022Z-a1b2c3",
+  "created_at": "2026-03-07T14:30:22Z",
+  "status": "pending",
+  "nonce": "<32 hex chars>",
+  "hmac": "<64 hex chars>",
+  "operation": "<operation name>",
+  "arguments": { ... },
+  "context": "<optional human-readable context>"
+}
+```
+
+**Response** (pushed to `responses/<id>.json` in the relay repo):
+
+```json
+{
+  "id": "20260307T143022Z-a1b2c3",
+  "completed_at": "2026-03-07T14:30:38Z",
+  "status": "completed",
+  "nonce": "<32 hex chars>",
+  "hmac": "<64 hex chars>",
+  "result": {
+    "success": true,
+    "content": "..."
+  }
+}
+```
+
+### Sending a Signed Message
+
+Use `relay_send.py` to construct, sign, and push a message:
+
+```bash
+# Send a request (Claude.ai side)
+GITHUB_TOKEN="..." RELAY_HMAC_SECRET="..." uv run scripts/relay_send.py \
+    fpl9000/claude-relay \
+    --direction request \
+    --operation memory_query \
+    --arguments '{"path":"core.md"}' \
+    --context "User asked from mobile: what's in my core memory?"
+
+# Send a response (bridge side)
+GITHUB_TOKEN="..." RELAY_HMAC_SECRET="..." uv run scripts/relay_send.py \
+    fpl9000/claude-relay \
+    --direction response \
+    --id "20260307T143022Z-a1b2c3" \
+    --status completed \
+    --result '{"success":true,"content":"# Core\n\nFran is a retired..."}'
+```
+
+### Receiving and Verifying a Message
+
+Use `relay_receive.py` to fetch, verify HMAC, validate timestamp, and return
+the payload:
+
+```bash
+# Receive a response (Claude.ai side, polling for a result)
+GITHUB_TOKEN="..." RELAY_HMAC_SECRET="..." uv run scripts/relay_receive.py \
+    fpl9000/claude-relay \
+    --direction response \
+    --id "20260307T143022Z-a1b2c3"
+```
+
+The script verifies the HMAC signature (constant-time comparison) and rejects
+messages whose timestamp is outside a ±5-minute window. Exit codes:
+- **0**: Verified successfully. Stdout contains `{"verified": true, "message": {...}}`.
+- **1**: Message not found (not yet available or expired).
+- **2**: HMAC verification failed (possible tampering).
+- **3**: Timestamp outside replay window.
+
+### Polling Strategy
+
+When waiting for a response from the local MCP bridge:
+
+- **Minimum polling interval:** 2 minutes for bridge-local operations
+  (`memory_query`, `shell_command`); 5 minutes for `claude_prompt`.
+- **Longer intervals are acceptable.** Use your judgment — if the bridge is
+  likely busy with a complex `claude_prompt` task, waiting longer before the
+  first poll is reasonable.
+- **Backoff on failure:** If a poll returns "not found" (exit code 1), double
+  the interval for the next attempt, up to a maximum of 5 minutes for
+  bridge-local ops and 10 minutes for `claude_prompt`.
+- **Maximum attempts:** Stop polling after 5 attempts for bridge-local ops
+  (total wall-clock ~10–15 minutes) or 4 attempts for `claude_prompt`
+  (total wall-clock ~20–30 minutes). Report to the user that the local
+  machine may be offline or the operation is still in progress.
+
+### Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| `relay_send.py` fails (exit code 1) | Report the GitHub API error to the user. Common cause: invalid token or repo not found. |
+| `relay_receive.py` exit code 1 (not found) | Message not yet available. Continue polling per the strategy above. |
+| `relay_receive.py` exit code 2 (HMAC failed) | **Potential tampering.** Report to the user that the response failed authentication. Do NOT use the message content. |
+| `relay_receive.py` exit code 3 (timestamp rejected) | Message is too old or clock skew is excessive. Report to the user. |
+| Max polling attempts reached | Inform the user that the local machine may be offline, sleeping, or the bridge is not running. |
+
+### HMAC Details (Reference)
+
+The HMAC is computed over canonicalized message fields using HMAC-SHA256:
+
+- **Request HMAC input:** `id + operation + nonce + canonical_json(arguments)`
+- **Response HMAC input:** `id + status + nonce + canonical_json(result)`
+
+Where `canonical_json()` serializes the JSON object with keys sorted alphabetically
+and compact separators (`","` `":"`). The `context` field in requests is NOT included
+in the HMAC (it is informational only).
+
+The nonce is 16 bytes of cryptographic randomness, hex-encoded (32 characters).
+Each message gets a fresh nonce.
+````
+
+#### 9.5.12 AI Messaging Skill
+
+The AI Messaging skill is a new skill created at `ai-skills/ai-messaging/SKILL.md`. It contains only a `SKILL.md` file (no scripts) and depends on the github skill's relay transport scripts.
+
+**Skill description** (for Claude Desktop/Claude.ai auto-invocation):
+
+```
+name: ai-messaging
+description: >
+  Communicate with the local stateful agent system via the GitHub relay.
+  Use this skill when the user wants to interact with their local machine
+  remotely — reading memory files, running shell commands, or delegating
+  tasks to the local Claude Desktop agent. Triggers include phrases like:
+  "on my local machine", "check my local files", "run this on my home
+  computer", "ask my local Claude", "read my memory files", "what's in
+  my core memory", "what's on my home machine", "run this locally".
+  Requires the github skill for relay transport scripts.
+```
+
+**Complete `SKILL.md` content:**
+
+````markdown
+---
+name: ai-messaging
+description: >
+  Communicate with the local stateful agent system via the GitHub relay.
+  Use this skill when the user wants to interact with their local machine
+  remotely — reading memory files, running shell commands, or delegating
+  tasks to the local Claude Desktop agent. Triggers include phrases like:
+  "on my local machine", "check my local files", "run this on my home
+  computer", "ask my local Claude", "read my memory files", "what's in
+  my core memory", "what's on my home machine", "run this locally".
+  Requires the github skill for relay transport scripts.
+---
+
+# AI Messaging Skill
+
+This skill enables Claude.ai (web or mobile) to communicate with the local
+stateful agent system running on Fran's home machine. It uses the GitHub relay
+transport protocol (provided by the github skill) to send signed requests to
+the local MCP bridge and receive signed responses.
+
+## Prerequisites
+
+- The **github skill** must be installed (provides `relay_send.py`,
+  `relay_receive.py`, and `relay_common.py` in its `scripts/` directory).
+- Environment variables `GITHUB_TOKEN` and `RELAY_HMAC_SECRET` must be set
+  (available via personal instructions).
+- The relay repository is `fpl9000/claude-relay`.
+
+## When to Use This Skill
+
+Use this skill when the user wants to do something that requires their local
+machine — a Windows 11 system running the MCP bridge server. Common triggers:
+
+- "Read my core memory" / "What's in my memory files?"
+- "Run this on my local machine" / "Check something on my home computer"
+- "Ask my local Claude to..." / "Have Claude Desktop do..."
+- "What's the status of [project] locally?"
+- "Run `git status` on my mcp-bridge repo"
+- Any reference to the local machine, local files, or the stateful agent system
+
+Do NOT use this skill for operations that can be performed directly from
+Claude.ai (e.g., reading GitHub repos via the github skill's existing scripts,
+web searches, or general knowledge questions).
+
+## Operations
+
+The relay supports three operations. Choose the simplest one that can
+accomplish the task.
+
+### memory_query
+
+Read a file from the local Layer 2 memory directory
+(`C:\franl\.claude-agent-memory\`). The MCP bridge handles this directly
+with no LLM inference — it simply reads the file and returns its contents.
+
+**When to use:** The user wants to see the contents of a specific memory
+file (core.md, index.md, or a block).
+
+**Arguments:**
+```json
+{"path": "core.md"}
+```
+
+The `path` is relative to the memory directory. Valid paths include:
+- `core.md` — Identity and active project summary
+- `index.md` — Block index table
+- `blocks/project-mcp-bridge.md` — A specific content block
+- `blocks/episodic-2026-03.md` — A specific episodic log
+
+**Example invocation:**
+```bash
+GITHUB_TOKEN="..." RELAY_HMAC_SECRET="..." uv run scripts/relay_send.py \
+    fpl9000/claude-relay \
+    --direction request \
+    --operation memory_query \
+    --arguments '{"path":"core.md"}'
+```
+
+**Response format:** `result.content` contains the full UTF-8 text of the file.
+If the file does not exist, `result.success` is `false` and `result.error`
+describes the problem.
+
+### shell_command
+
+Execute a shell command on the local machine via Cygwin bash. The MCP bridge
+handles this directly with no LLM inference — it runs the command and returns
+stdout/stderr. This is equivalent to the bridge's `run_command` tool.
+
+**When to use:** The task can be expressed as a single shell command or short
+pipeline and requires no LLM reasoning. Examples: `git status`, `ls -la`,
+`grep -r 'TODO' src/`, `cat some-file.txt`, `wc -l *.go`.
+
+**Arguments:**
+```json
+{
+  "command": "cd /c/franl/git/mcp-bridge && git log --oneline -5",
+  "timeout_seconds": 60
+}
+```
+
+- `command` (required) — The shell command to execute.
+- `timeout_seconds` (optional, default: 120) — Maximum runtime before the
+  command is killed.
+
+**Example invocation:**
+```bash
+GITHUB_TOKEN="..." RELAY_HMAC_SECRET="..." uv run scripts/relay_send.py \
+    fpl9000/claude-relay \
+    --direction request \
+    --operation shell_command \
+    --arguments '{"command":"cd /c/franl/git/mcp-bridge && git log --oneline -5"}'
+```
+
+**Response format:** `result.content` contains the combined stdout+stderr.
+`result.exit_code` contains the process exit code (0 = success).
+`result.timed_out` is `true` if the command exceeded its timeout.
+
+### claude_prompt
+
+Forward a prompt to Claude Desktop for full agent-loop processing. Claude
+Desktop receives the prompt, performs whatever tool calls it deems appropriate
+(reading memory, running commands, spawning sub-agents, writing memory
+updates), and returns its final response.
+
+**When to use:** The task requires LLM reasoning, multi-step tool use, or
+memory writes. Examples:
+- "Summarize today's episodic log and update core.md"
+- "Read the mcp-bridge project block and tell me what the open issues are"
+- "Refactor the error handling in server.go"
+- "Create a new memory block for the dashboard-v2 project"
+
+**Arguments:**
+```json
+{
+  "prompt": "Read the mcp-bridge project block and summarize the current open issues."
+}
+```
+
+- `prompt` (required) — The task prompt for Claude Desktop. Write it as if
+  you were typing directly into Claude Desktop's input field. Be specific
+  and self-contained — Claude Desktop does not have context from the
+  current Claude.ai conversation.
+
+**Example invocation:**
+```bash
+GITHUB_TOKEN="..." RELAY_HMAC_SECRET="..." uv run scripts/relay_send.py \
+    fpl9000/claude-relay \
+    --direction request \
+    --operation claude_prompt \
+    --arguments '{"prompt":"Read the mcp-bridge project block and summarize the current open issues."}'
+```
+
+**Response format:** `result.content` contains Claude Desktop's final text
+response. This may be lengthy if the task involved analysis or summarization.
+
+## Decision Tree
+
+When the user asks you to do something on their local machine, choose the
+operation using this decision tree:
+
+1. **Is the user asking to read a specific memory file?**
+   → Use `memory_query`. This is instant (no inference) and costs nothing.
+
+2. **Can the task be expressed as a single shell command?**
+   → Use `shell_command`. Fast, cheap, no inference involved.
+
+3. **Does the task require LLM reasoning, multi-step actions, or memory writes?**
+   → Use `claude_prompt`. This is the most capable but slowest option.
+
+When in doubt, prefer the simpler operation. You can always escalate — for
+example, if a `memory_query` reveals that you need to read multiple files
+and synthesize them, follow up with a `claude_prompt`.
+
+## End-to-End Workflow
+
+Here is the complete sequence for a typical relay interaction:
+
+1. **User asks:** "What are my active projects on my local machine?"
+
+2. **Choose operation:** This is a memory file read → `memory_query` for `core.md`.
+
+3. **Send the request:**
+   ```bash
+   export GITHUB_TOKEN="..."
+   export RELAY_HMAC_SECRET="..."
+   ID=$(uv run scripts/relay_send.py fpl9000/claude-relay \
+       --direction request \
+       --operation memory_query \
+       --arguments '{"path":"core.md"}')
+   ```
+
+4. **Inform the user:** "I've sent a request to your local machine to read
+   your core memory file. I'll check for a response in about 2 minutes."
+
+5. **Poll for the response** (after minimum interval):
+   ```bash
+   uv run scripts/relay_receive.py fpl9000/claude-relay \
+       --direction response \
+       --id "$ID"
+   ```
+
+6. **Handle the result:**
+   - If exit code 0: Parse the verified response and present the content
+     to the user naturally.
+   - If exit code 1 (not found): Wait longer, then poll again (with backoff).
+   - If exit code 2 (HMAC failed): Alert the user to a potential security issue.
+   - If max attempts reached: Inform the user their machine may be offline.
+
+7. **Present the answer:** Summarize the core.md contents in response to
+   the user's question.
+
+## Important Notes
+
+- **The local machine must be running.** The MCP bridge polls the relay repo
+  periodically (default: every 15 seconds). If the machine is off, sleeping,
+  or the bridge is not running, requests will go unanswered.
+
+- **Latency is inherent.** Round-trip times of 1–5 minutes are normal for
+  bridge-local operations; `claude_prompt` may take 5–15 minutes depending
+  on task complexity. Set expectations with the user.
+
+- **Prompts for `claude_prompt` must be self-contained.** Claude Desktop
+  does not have access to the current Claude.ai conversation. Include all
+  necessary context in the prompt itself.
+
+- **HMAC failures are serious.** If `relay_receive.py` reports an HMAC
+  verification failure, do not use the response content. Report the issue
+  to the user.
+
+- **One request at a time.** Do not send multiple relay requests
+  simultaneously. Wait for each response (or timeout) before sending
+  the next request. This simplifies the interaction and avoids overwhelming
+  the bridge's polling loop.
+````
+
 ---
 
 ## 10. References
@@ -2781,7 +3232,17 @@ If the bridge gains Streamable HTTP transport and a Cloudflare Tunnel (Section 9
 
 12. **Claude.ai SKILL.md contents needed** — Section 9.5, "GitHub Relay: Claude.ai to Local Bridge Communication", needs to include the contents of the skill, including the `SKILL.md` file and the names of any scripts.
 
-    - *Resolution:* TBD
+    - *Resolution:* The relay functionality is split across two skills to maintain a clean separation between the transport protocol and the operational semantics:
+
+      **(a) GitHub skill** (`ai-skills/github/`) — Gains three new scripts (`relay_common.py`, `relay_send.py`, `relay_receive.py`) and a new SKILL.md section covering the relay *transport protocol*: message format, HMAC signing and verification, polling strategy, and error handling. The transport layer is operation-agnostic — it treats the `operation` and `arguments` fields as opaque payloads.
+
+      **(b) AI Messaging skill** (`ai-skills/ai-messaging/`) — A new skill containing only a `SKILL.md` file (no scripts). Covers the *semantic layer*: the three relay operations (`memory_query`, `shell_command`, `claude_prompt`), when to choose each one, what arguments they expect, and how to interpret results. This skill depends on the github skill's relay scripts for actual message transport. The dependency is explicit and one-directional (ai-messaging → github, never the reverse).
+
+      This separation avoids mixing two distinct concerns in a single skill: the mechanical details of how messages are signed, delivered, and verified (transport) vs. the domain-specific knowledge of what operations are available and when to use each one (semantics). It also prevents the github skill's description from needing to serve two very different trigger patterns ("create a PR" vs. "read my local memory"), which could degrade auto-invocation accuracy.
+
+      The `RELAY_HMAC_SECRET` environment variable value is stored in the user's Claude.ai personal instructions (the `<userPreferences>` block), alongside the existing `GITHUB_TOKEN` and Bluesky credentials. These instructions are shared by both Claude Desktop and Claude.ai, so both environments have access to the secret.
+
+      See [Section 9.5.10](#9510-relay-script-inventory) for the script specifications, [Section 9.5.11](#9511-github-skill-relay-transport-additions) for the github skill SKILL.md additions, and [Section 9.5.12](#9512-ai-messaging-skill) for the ai-messaging skill's complete SKILL.md.
 
 ---
 


### PR DESCRIPTION
## Summary

Resolves Open Question #12: "Claude.ai SKILL.md contents needed" from the stateful agent design document.

## Design Decision

The relay functionality is split across **two skills** to maintain a clean separation between transport mechanics and operational semantics:

1. **GitHub skill** (transport layer) — Gains three new scripts (`relay_common.py`, `relay_send.py`, `relay_receive.py`) and a new SKILL.md section covering the relay protocol: message format, HMAC signing/verification, polling strategy, error handling. Operation-agnostic.

2. **AI Messaging skill** (semantic layer) — New skill at `ai-messaging/SKILL.md` covering the three relay operations (`memory_query`, `shell_command`, `claude_prompt`), when to choose each, arguments, response formats, and an end-to-end workflow example. Depends on the github skill for transport scripts.

This avoids mixing two distinct trigger patterns in a single skill description ("create a PR" vs. "read my local memory"), which could degrade auto-invocation accuracy.

## Changes

### `docs/stateful-agent-design.md`
- **Section 9.5.10** — Relay script inventory: specs for `relay_common.py`, `relay_send.py`, `relay_receive.py`
- **Section 9.5.11** — GitHub skill relay transport additions: complete SKILL.md section for the transport protocol (message format, HMAC, polling, errors)
- **Section 9.5.12** — AI Messaging skill: complete SKILL.md content (operations, decision tree, workflow, notes)
- **Section 11, OQ#12** — Resolution text explaining the two-skill split, HMAC secret storage in personal instructions, and cross-references to the new subsections

### `ai-messaging/SKILL.md` (new file)
- Complete skill file ready for packaging as a .zip and uploading to Claude Desktop/Claude.ai

## Key Design Details

- **Polling strategy**: 2-min minimum for bridge-local ops, 5-min minimum for `claude_prompt`, with doubling backoff on failures
- **HMAC secret**: Stored in Claude.ai personal instructions (`<userPreferences>` block)
- **One request at a time**: v1 constraint to simplify interaction
- **`shell_command` is unrestricted**: Same security model as the bridge's `run_command` tool
- **Scripts are not yet implemented**: This PR adds the design specification; implementation is a future task