### PR TITLE
Fix design review issue 1.1: first-write race on new files

### DIFF
--- a/docs/stateful-agent-design/stateful-agent-design-chapter3.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter3.md
@@ -671,7 +671,7 @@ func HandleSafeWriteFile(params SafeWriteFileParams) SafeWriteFileResult:
         currentModTime = os.Stat(absPath).ModTime()
         lastSeenModTime = sessionTracker.GetLastRead(params.SessionID, absPath)
 
-        if lastSeenModTime != nil && currentModTime.After(*lastSeenModTime):
+        if lastSeenModTime == nil || currentModTime.After(*lastSeenModTime):
             // Race detected: the file was modified by another conversation
             // since this session last read it. Write to a branch file instead
             // of overwriting the other conversation's changes.
@@ -778,7 +778,7 @@ func HandleSafeAppendFile(params SafeAppendFileParams) SafeAppendFileResult:
         currentModTime = os.Stat(absPath).ModTime()
         lastSeenModTime = sessionTracker.GetLastRead(params.SessionID, absPath)
 
-        if lastSeenModTime != nil && currentModTime.After(*lastSeenModTime):
+        if lastSeenModTime == nil || currentModTime.After(*lastSeenModTime):
             // Race detected. For append operations, the branch file is created
             // by copying the current base file content, then appending to the copy.
             // This preserves the full context in the branch.
@@ -889,7 +889,9 @@ Branching is the mechanism that resolves the concurrent read-modify-write race c
 
 **When branching occurs:** A branch is created when ALL of the following conditions are true: (a) `config.Branching.Enabled` is `true`; (b) the target file already exists on disk; (c) the session tracker has a recorded `ModTime` for this file in the current session (meaning `safe_read_file` was previously called); (d) the file's current `ModTime` is newer than the session's recorded `ModTime` (meaning another conversation wrote to the file after this session last read it).
 
-**When branching does NOT occur:** If the session has never read the file (e.g., creating a brand-new block), no baseline exists and no race is possible — the write proceeds normally. If branching is disabled in config, all writes use last-writer-wins semantics (the v1 behavior). If the `ModTime` matches, no race has occurred and the write proceeds normally.
+**When branching does NOT occur:** If the target file does not exist at write time (true first-ever creation by anyone), no baseline exists and no race is possible — the write proceeds normally. If branching is disabled in config, all writes use last-writer-wins semantics (the v1 behavior). If the `ModTime` matches the session's last-seen value, no race has occurred and the write proceeds normally.
+
+**When the file exists but this session has never read it**, that is treated as a race: another conversation created or modified the file since this session began, and this session's write is redirected to a branch. This covers the "simultaneous first write" scenario where two conversations independently decide to create the same new block file — the second writer always branches rather than silently overwriting the first.
 
 **Branch file naming convention:**
 


### PR DESCRIPTION
## Summary

Fixes **issue 1.1** from the Opus 4 design review: *"File-creation races are completely unprotected."*

## Problem

The race detection condition in `safe_write_file` (§3.9) and `safe_append_file` (§3.10) was:

```
if lastSeenModTime != nil && currentModTime.After(*lastSeenModTime):
    // branch
```

The `lastSeenModTime != nil` guard meant that if a file existed on disk but the current session had never read it, the write bypassed branching entirely and silently overwrote whatever another conversation had written. This is a real race: two conversations independently deciding to create the same new block file, with the second writer clobbering the first.

The same gap applied to `index.md` and episodic log files on first write of a new month.

§3.12 compounded the problem by explicitly (and incorrectly) stating: *"no baseline exists and no race is possible"* for files a session has never read.

## Fix

**§3.9 and §3.10** — change the condition to:

```
if lastSeenModTime == nil || currentModTime.After(*lastSeenModTime):
    // branch
```

Now, if the file exists AND this session has never seen it, a race is assumed and the write goes to a branch. The only case where a write to an existing file does NOT branch is when the session's recorded ModTime matches the file's current ModTime — i.e., the file hasn't changed since this session last touched it.

A session's own writes are still safe: `RecordRead()` is called after every successful write (step 8 in §3.9), keeping `lastSeenModTime` current and preventing spurious self-branching.

**§3.12** — replace the incorrect prose with an accurate description:
- Branching does NOT occur when the file does not exist at write time (true first-ever creation).
- Branching DOES occur when the file exists but this session has never read it.

## Files Changed

- `docs/stateful-agent-design/stateful-agent-design-chapter3.md`
  - §3.9: fix race detection condition in `safe_write_file` pseudo-code
  - §3.10: fix race detection condition in `safe_append_file` pseudo-code  
  - §3.12: rewrite the "When branching does NOT occur" paragraph