### PR TITLE
docs: Add analysis of memory-aware tools discussion

### DIFF
--- a/docs/stateful-agent-design/memory-aware-tools-analysis.md
+++ b/docs/stateful-agent-design/memory-aware-tools-analysis.md
@@ -1,0 +1,322 @@
+# Analysis of the Memory-aware Tools Discussion
+
+**Reviewer:** Claude Opus 4.7
+**Date:** May 2026
+**Subject:** `memory-aware-tools-idea.md` (transcript of design discussion with Claude Sonnet 4.6)
+**Purpose:** Surface flaws, inconsistencies, and omissions before the Stateful Agent Design document is updated to incorporate the proposed redesign.
+
+---
+
+## 1. Summary of Ratified Decisions
+
+For reference, the discussion converged on these architectural decisions:
+
+1. **Memory-aware tools** replace the current file-centric API (`safe_read_file`, `safe_write_file`, `safe_append_file`). The bridge exposes semantic operations on memory concepts (blocks, index, core), not on files.
+2. **Branches are completely invisible to the LLM**. Conflict resolution happens entirely in the bridge.
+3. **Option B** (background async merge during an unattended "wake-up phase") was chosen over Option A (LLM-performed merges with branches surfaced as embedded conflict data) and Option C (serve-best-available with background flag).
+4. **Session identity is carried by an opaque "handle"** returned from `memory_start_conversation` and echoed back in every memory tool response.
+5. **Graceful re-initialization** on unknown handle: bridge silently creates a new session rather than returning a hard error. Failure mode is spurious branches (over-protection), never silent data loss.
+6. **`memory_get_index()`** returns the index as structured data (parsed object), not raw markdown. The bridge owns serialization to/from disk and applies row-level merge rules mechanically.
+7. **`memory_write_block`** atomically updates both the block file and its index entry (optionally taking a `summary` parameter).
+
+These are the right decisions in broad strokes. The issues below concern specifics that the discussion either resolved inconsistently, glossed over, or left implicit.
+
+---
+
+## 2. Critical Issues
+
+These must be resolved before the design document is rewritten, because they either contain self-contradictions or leave essential mechanics undefined.
+
+### 2.1 — Tool signatures omit the handle parameter
+
+The tool surface table (transcript lines 98–107) shows:
+
+```
+memory_get_core()
+memory_write_core(content)
+memory_get_index()
+memory_get_block(name)
+memory_write_block(name, content, summary?)
+memory_append_block(name, content)
+```
+
+But the discussion concludes elsewhere (lines 178–183, 233–246) that the session ID/handle **must** be threaded through every call because the bridge has no other way to distinguish concurrent conversations sharing the single stdio pipe. The table is inconsistent with that conclusion. The correct signatures are:
+
+```
+memory_start_conversation()            → { handle: "abc1" }
+memory_get_core(handle)                → { handle: "abc1", content: ... }
+memory_write_core(handle, content)     → { handle: "abc1", ok: true }
+memory_get_index(handle)               → { handle: "abc1", index: { blocks: [...] } }
+memory_get_block(handle, name)         → { handle: "abc1", content: ... }
+memory_write_block(handle, name, content, summary?)
+                                       → { handle: "abc1", ok: true }
+memory_append_block(handle, name, content)
+                                       → { handle: "abc1", ok: true }
+```
+
+This isn't a minor notational issue — it's a contradiction between two parts of the same proposal. The design document must commit to one interpretation.
+
+### 2.2 — Read-your-own-writes through an "invisible branch" is not defined
+
+This is the most consequential omission in the discussion. Consider this sequence within a single conversation X:
+
+1. X writes content C1 to block B via `memory_write_block(handle_X, "B", C1)`.
+2. A concurrent conversation Y had previously read B, so X's write triggers branch creation. X writes to `B.branch-...md`. Base `B.md` retains its prior content.
+3. X later calls `memory_get_block(handle_X, "B")`.
+
+What does X see?
+
+- **If the bridge returns the base file**, X loses the ability to see its own writes within the same conversation. This is a read-your-own-writes violation and breaks the LLM's mental model of "I just wrote this, I should be able to read it back." The discussion's framing — "from the LLM's perspective, memory reads always return _the_ current state of a block, full stop" (line 288) — is silently false in this case.
+- **If the bridge returns X's branch**, then the bridge must track `handle → block → branch` mapping and resolve reads against that map. This is workable, but the discussion never articulates it as a requirement.
+
+The same problem applies across multiple writes within the conversation: X writes to B, then writes to B again. Does the second write append to X's branch, or create a second branch of X's branch? Branch-of-branch isn't a structure the current design supports.
+
+**Recommendation:** Make explicit that the bridge maintains a per-handle view of each memory block. Reads from handle H always return `branches[H][block]` if it exists, otherwise the base file. Writes from H update `branches[H][block]`, never the base file directly when other sessions have outstanding reads. Merging (during the wake-up phase) folds all per-handle branches back into the base. This is a much cleaner model than "branches appear when there's a race" and it cleanly preserves read-your-own-writes.
+
+### 2.3 — The wake-up phase mechanism is unspecified
+
+The discussion repeatedly defers merging to "the wake-up phase" or "off-peak hours" (lines 287, 290) without specifying:
+
+- What schedules it
+- What process executes it
+- How it gets the credentials/permissions to invoke an LLM for prose merges
+
+This matters because, per the existing memory context, Anthropic's Dispatch for Claude Cowork is Mac-only and unsuitable for the target Windows 11/Cygwin environment. The relay protocol (§9.5) had to be restructured precisely because of this. Option B inherits exactly the same dependency: it presumes an automated unattended Claude invocation path that the existing design has already established does not yet exist on this user's platform.
+
+In practice, Option B in v1 may need to fall back to one of:
+
+- **A scheduled task** (Windows Task Scheduler) that invokes `claude -p` locally with a merge prompt. Lightweight; works on Windows. Requires the bridge to record pending merges in a persistent queue.
+- **Lazy merging on next session start.** When `memory_start_conversation` runs, the bridge synchronously merges any pending branches before returning. Adds latency to conversation startup but eliminates the unattended-execution problem entirely. Cost is paid in tokens at session start rather than during a separate wake-up window.
+- **Manual user trigger.** The bridge exposes a `memory_run_maintenance` tool the user can ask Claude to invoke when convenient.
+
+Without picking one, "Option B" is more aspirational than designed. Worth selecting an explicit path before the rewrite — and worth being honest in the rewritten design that the wake-up phase mechanism is the lever the entire correctness story now hangs on.
+
+### 2.4 — Atomic block-plus-index update is asserted but not specified
+
+The discussion states (lines 88–90) that `memory_write_block` "atomically" updates both the block file and the index. Two separate files cannot be updated truly atomically on a stock filesystem without either a journal or write-ahead log. Three failure modes need to be addressed:
+
+- Bridge crashes after writing the block but before updating the index → orphan block, no index entry.
+- Bridge crashes after the index update but before the block write completes → index points at an empty or missing block.
+- One write triggers a branch and the other doesn't (e.g., the block races but the index doesn't) → divergent state.
+
+The simplest correct approach is **index-first, block-second, with index entry quarantined until the block write succeeds.** Concretely: write a temp block file, update the index referencing the temp path, fsync, then atomic-rename the temp to the canonical name. A crash recovery sweep at bridge startup reconciles any unfinished operations.
+
+The design document needs to either commit to a specific ordering and crash-recovery story, or explicitly accept "atomic" as best-effort with a documented inconsistency window.
+
+### 2.5 — The first tool call after a forgotten `memory_start_conversation` is undefined
+
+If the LLM skips `memory_start_conversation` (whether due to compaction or SKILL non-compliance) and calls `memory_get_block(handle, "B")` directly, several things could happen:
+
+- The handle parameter is missing → MCP validation rejects the call → LLM has to recover.
+- The handle parameter is present but invalid (the LLM made one up) → bridge's graceful re-init kicks in → new empty session with the LLM's invented handle → works.
+- The LLM passes `null` or an empty string → bridge behavior undefined.
+
+This is exactly the failure mode the redesign is meant to eliminate, so it deserves an explicit answer. The cleanest options are:
+
+- **Handle is a required parameter.** The LLM cannot call any memory tool without one. This forces compliance via the MCP protocol rather than via SKILL prose.
+- **Handle is optional; bridge auto-generates one on the first call without it.** First tool response carries the generated handle. `memory_start_conversation` becomes a courtesy, not a requirement. This is the most failure-tolerant choice and aligns with the discussion's stated goal of minimizing compliance burden.
+
+Pick one; the discussion currently implies both at different points.
+
+---
+
+## 3. Inconsistencies Within the Discussion
+
+These are places where the discussion's own logic contradicts itself, separate from underspecified mechanics.
+
+### 3.1 — "Session tracking happens entirely in-bridge without LLM involvement"
+
+This was the original framing in the opening prompt (line 9). The discussion then established correctly that the LLM **must** participate by passing the handle on every call, because the stdio transport provides no per-conversation identifier (lines 158–159, 179–183). The redesign therefore does **not** achieve "entirely in-bridge" session tracking — it achieves a reduced-fragility version of LLM-involved tracking. The summary at the end (line 302) still uses the softer phrasing "implicit in the bridge, surfaced to LLM as an opaque handle," which is more accurate.
+
+The rewritten design should be clear that the handle is an explicit parameter passed by the LLM on every memory tool call, not a hidden mechanism — only the *interpretation* of the handle is bridge-internal. The behavioral nudge from calling it a "handle" instead of a "session ID" doesn't change this technical reality; it changes how the LLM treats the value.
+
+### 3.2 — `memory_start_conversation` return value
+
+Three different statements of what this tool returns appear in the discussion:
+
+- Line 32: `memory_start_conversation() → { "ok": true }` — no meaningful return.
+- Line 100: "No return value to track" (in the comparison table).
+- Lines 240–246: The handle is returned in every tool response, which means `memory_start_conversation` returns one too.
+- Line 299: "memory_start_conversation requires no meaningful return value beyond the handle" — final reconciliation.
+
+The final position is consistent but the earlier text is left dangling. When the design document is updated, it should use only the final framing: `memory_start_conversation` returns the handle. There is no contradiction between "the handle is the return value" and "no value the LLM has to interpret"; the LLM treats the handle as opaque infrastructure.
+
+### 3.3 — "Memory-aware tools" conflates two separable improvements
+
+The discussion uses "memory-aware tools" as a single label for what is really two independent design moves:
+
+- **Semantic API surface.** Tools operate on memory concepts (`block`, `index`, `core`) rather than files. The bridge owns file paths, file formats, and directory layout.
+- **Implicit session management.** Branches, race detection, and merging are hidden from the LLM. The LLM sees only "read this block, write that block."
+
+These are independent — you could have one without the other. The redesign chose to do both at once, which is fine, but the rewritten chapter should explicitly identify them as two pillars rather than one undifferentiated change. This matters for the SKILL chapter: the simplifications it enables come primarily from the second pillar, not the first.
+
+### 3.4 — The "Option A is unusual because it exposes branches to the LLM" argument
+
+Fran's rejection of Option A is sound, and the rationale (lines 272–277) is consistent. But Option A doesn't actually expose branch *filenames* to the LLM — it surfaces conflict content as labeled "version-1" and "version-2" data inside the tool response. The branch *implementation* remains hidden. The decision against Option A is defensible on simplicity and SKILL-instruction-load grounds, but the discussion overstates how much Option A leaks. Worth being precise about this in the design document so that future readers (or future Claudes reviewing the design) understand what was actually decided and why, rather than inheriting an inaccurate characterization.
+
+### 3.5 — `safe_append_file` collapsing into `memory_append_block`
+
+The tool table (line 106) maps `memory_append_block(name, content)` to `safe_append_file(...)` and labels it "Episodic log appends." But the existing design treats episodic logs as a distinct concept stored as `episodic-YYYY-MM.md`, not as files in the `blocks/` directory. Folding them under "blocks" is a model change that the discussion makes implicitly without flagging it.
+
+Either:
+
+- Episodic logs remain a separate concept, in which case `memory_append_episodic(handle, content)` or similar deserves its own tool with bridge-managed file rotation by month.
+- Episodic logs become "just another block" with a naming convention, in which case the SKILL needs explicit guidance on the monthly-rotation rules and Chapter 4's file-layout section needs updating.
+
+The implicit collapse is risky because the existing design has explicit rules about episodic logs that wouldn't survive the conceptual flattening without re-derivation.
+
+---
+
+## 4. Significant Omissions
+
+### 4.1 — The schema of `memory_get_index()` is not specified
+
+The discussion gestures at "structured data" but doesn't specify it. At minimum the design needs:
+
+- The exact JSON schema returned (e.g., `{ blocks: [{ name, summary, updated_at }] }`).
+- Whether ordering is stable (sorted by name? by updated_at? insertion order?).
+- Whether the response is paginated or capped (relevant once §5.8 of the design review applies — index growth is unbounded).
+- The schema-evolution story (the design review's §6.2 raised this already; the redesign doesn't address it).
+
+### 4.2 — Concurrent appends are not analyzed
+
+Appends are naturally less race-prone than overwrites but not race-free. Two conversations appending to the same episodic log can interleave their content or produce two branches. The discussion never mentions append semantics. Possible approaches:
+
+- Bridge serializes all appends via the existing mutex; no branching on append; last-arrived wins the tail position. Acceptable for episodic logs where chronological ordering is approximate anyway.
+- Bridge branches on append the same way as on write. Adds complexity for marginal benefit.
+
+The first option is probably right; it should be stated explicitly.
+
+### 4.3 — The `summary` parameter's semantics are unclear
+
+`memory_write_block(handle, name, content, summary?)` carries an optional summary. The discussion is silent on:
+
+- Is `summary` required for a new block (so the index has an entry) and optional for an existing block?
+- If `summary` is omitted for an existing block, does the existing index summary persist unchanged, or is it cleared?
+- Can `summary` be passed as the empty string to explicitly clear it?
+- What's the maximum length?
+
+### 4.4 — `memory_get_index` interacts with branched blocks ambiguously
+
+If conversation X has a branch of block B (per the per-handle model recommended in §2.2), does `memory_get_index(handle_X)` show:
+
+- The base index (no awareness of X's branch)?
+- X's view of the index (showing the updated_at from X's branch write)?
+
+The latter is consistent with the read-your-own-writes principle but requires per-handle index views. Worth being explicit.
+
+### 4.5 — Handle lifetime and cleanup are unspecified
+
+The current design has a session tracker with a capacity limit and (problematic, per design review §1.3) eviction. The handle-based design inherits this question: how long does a handle remain valid? Until Claude Desktop disconnects? Until N hours of inactivity? Indefinitely?
+
+If handles are persisted (per design review §3.1's recommendation), then handle lifetime extends across bridge restarts. This is a desirable property — it would make compaction-loss-of-handle recoverable across restarts — but requires explicit design.
+
+### 4.6 — No mention of `memory_delete_block` or `memory_rename_block`
+
+Eventually needed but presumably out of scope for v1. The discussion doesn't even acknowledge them, which is fine, but the design document should note them as deferred so they don't appear as new requirements later.
+
+### 4.7 — The interaction between `memory_write_block` index updates and concurrent index writes
+
+If conversation X calls `memory_write_block` and the block write produces a branch (race detected against conversation Y), the index update inside the same operation must also somehow handle the race. The bridge's row-level mechanical merge for the index can absorb most conflicts (latest-wins per cell, union of rows). But the discussion doesn't say explicitly whether:
+
+- The index update inside `memory_write_block` is always merged in-place to the canonical index (no branch ever produced for the index).
+- Or whether the index can itself produce a per-handle branch, requiring a wake-up-phase merge.
+
+The first option is much cleaner: because the merge is mechanical, there's no reason to defer it. The index has no "branched" state; it's always live. This should be stated explicitly.
+
+### 4.8 — The bridge's branch storage model needs articulating
+
+§2.2 above recommends per-handle branches. That implies the on-disk layout becomes something like:
+
+```
+core.md
+core.branch-<handle>-<timestamp>.md
+blocks/foo.md
+blocks/foo.branch-<handle>-<timestamp>.md
+```
+
+The handle is now part of the filename pattern. This:
+
+- Changes design-review §2.9's regex (the SKILL no longer needs to parse branch names, but the bridge does, and external users browsing the directory will see handles in filenames).
+- Subsumes design review §3.2's recommendation to "annotate branches with their session ID" — it's automatic.
+- Means handle persistence (§4.5 above) becomes correctness-critical, not just convenience: if a handle is forgotten by the bridge but its branch files remain on disk, those branches become orphaned and need a cleanup process (likely the wake-up phase).
+
+---
+
+## 5. Concerns and Trade-offs Worth Acknowledging
+
+These aren't omissions or contradictions — they're real trade-offs that the redesign should acknowledge explicitly so future readers understand the rationale.
+
+### 5.1 — Option B routes merges to a less context-aware Claude
+
+Option A had a quality advantage that the discussion didn't weigh: the in-context Claude performing the merge has full visibility into *why* the changes were made. The wake-up-phase merger is an isolated `claude -p` invocation with only the two file versions to reconcile. For subtle semantic merges (two conversations updating overlapping prose about the same topic), the wake-up-phase merger may produce strictly worse merges than the in-context Claude would have. Option B wins on simplicity and abstraction-cleanness; it does not necessarily win on merge quality. Worth saying so.
+
+### 5.2 — "Handle" is a behavioral nudge, not a technical guarantee
+
+The discussion correctly notes that calling the session ID a "handle" aligns it with a pattern LLMs have been heavily trained on. This is a reasonable nudge but it's just that — a nudge. There's no mechanism preventing the LLM from inspecting the handle, trying to interpret it, or carrying a stale one. The graceful re-init on unknown handle and the echo-back-in-every-response are the actual technical guarantees. The handle naming is a soft mitigation layered on top. The design document should be clear about which protections are technical and which are behavioral.
+
+### 5.3 — Loss of the `branches_exist` signal
+
+The current design's `memory_session_start` returns a `branches_exist` flag, allowing the LLM to know maintenance work is pending. With branches invisible, this signal is gone. This is consistent with the new abstraction, but it means the LLM has no way to suggest "you should run a merge now" or notice that the system is accumulating debt. If wake-up-phase merging falls behind (because the user rarely leaves the machine idle, or the trigger mechanism is fragile), branches accumulate silently. A status tool (`memory_get_health(handle)` → `{ pending_merges: 7, oldest_branch_age_days: 14 }`) is worth considering, ideally exposed only to administrative conversations, not surfaced in the SKILL.
+
+### 5.4 — Accidental handle collision goes undetected
+
+Because the bridge accepts any handle and re-inits unknown ones gracefully, two conversations could (in theory) be assigned or invent the same handle and have their read histories mixed. For a single-user system with a handful of concurrent conversations, four alphanumeric characters is more than adequate — birthday-bound collisions in that space are vanishingly rare at the relevant scale. But the design should be explicit on two points:
+
+- The bridge should generate handles itself rather than accepting arbitrary LLM-supplied ones for new sessions. If the LLM ever fabricates a handle that happens to match an active session, the bridge would silently merge their histories. Making the graceful-re-init path the only way an LLM-supplied handle can land (and verifying the bridge doesn't currently track it) eliminates this.
+- If multi-user or higher-volume usage is ever a goal, 4 characters is too few. Picking the parameter consciously and saying "we accept the limitation for v1" is fine; leaving it as a casual default is not.
+
+### 5.5 — The SKILL is simpler but not as simple as the discussion implies
+
+The discussion says the SKILL "doesn't need to explain sessions, branches, file paths, or race detection to Claude at all" (line 108). Mostly true. But the SKILL still needs to cover:
+
+- When and how to call `memory_start_conversation` (or how to handle the bridge auto-initializing).
+- How to use the handle (treat as opaque; pass it identically; use the most recent one returned).
+- The mental model of what's in core vs. blocks vs. index.
+- When to create new blocks vs. update existing ones.
+- The optional `summary` parameter semantics.
+- What to do when a memory tool returns an error (not a graceful re-init case, but e.g., disk full).
+
+This is much smaller than the current SKILL, but it isn't trivial. The rewritten Chapter 5 shouldn't promise more simplification than it can deliver.
+
+---
+
+## 6. Positives Worth Preserving Explicitly
+
+So they don't get diluted or lost when the design is rewritten:
+
+1. **Handle echoed in every tool response** is a strong design choice. Even if compaction removes most tool responses, any remaining one re-establishes the handle. This is robust to a much wider range of compaction patterns than "handle returned only by `memory_start_conversation`."
+
+2. **Graceful re-init on unknown handle** is the right failure mode. It converts a class of hard errors into a class of spurious branches, which the system already has to handle. The asymmetry (over-protection always, never under-protection) is correctly emphasized in the discussion (line 35).
+
+3. **Index as a structured object with mechanical merging** eliminates the design-review §1.2 concern (semantic merge on a table) entirely. This is a significant correctness improvement, not just a clean-API improvement.
+
+4. **Atomic block + index update** (subject to §2.4's caveats about cross-file atomicity) removes the "Claude must remember to update the index" compliance burden, which was a real source of fragility.
+
+5. **The honest summary at line 187–193**, where the discussion acknowledges that the session-ID requirement cannot be eliminated, is the right tone. The redesign improves robustness without overclaiming. The rewritten design should preserve this honesty.
+
+---
+
+## 7. Recommendations for the Design Rewrite
+
+Beyond resolving the specific issues above, three structural recommendations:
+
+### 7.1 — Make the per-handle branch model explicit in Chapter 3
+
+The most consequential structural change is moving from "branches as race-resolution mechanism" to "branches as per-handle views of memory." Chapter 3 should describe the bridge's branch storage model with concrete file-layout examples, the rules for which file gets returned on a read (per-handle branch if present, base otherwise), and the wake-up-phase fold-back algorithm.
+
+### 7.2 — Choose and document the wake-up-phase mechanism in Chapter 9
+
+§9.5 already had to be restructured because Dispatch is Mac-only. The wake-up phase is now load-bearing for the entire correctness story. Pick a mechanism (Windows Task Scheduler invoking `claude -p`, lazy merge at next session start, manual trigger, or something else) and write it up before merging the redesign. Without this, "Option B" is gestural rather than designed.
+
+### 7.3 — Resolve the handle-required-vs-optional question in Chapter 5 (SKILL)
+
+Whichever is chosen (handle as required parameter, or auto-generation on first call), Chapter 5's instructions to Claude should match. If handle is required, the SKILL must instruct Claude to always call `memory_start_conversation` first. If auto-generation is allowed, the SKILL can be simpler ("just call any memory tool; the bridge handles initialization"). Pick one and write the SKILL to match.
+
+---
+
+## 8. Closing Note
+
+The redesign is a substantial improvement over the current design — it correctly identifies the leaky-abstraction problem, picks reasonable solutions, and arrives at a coherent architectural direction. The issues raised above are gaps and rough edges in the discussion, not fundamental flaws in the direction. Resolving them before the rewrite will produce a design that is materially more implementable than the current document.
+
+The single most important issue to settle before rewriting is **§2.2 (read-your-own-writes through invisible branches)**. The per-handle branch model that resolves it has implications for the on-disk layout, the wake-up-phase algorithm, the handle lifetime story, and the orphaned-branch cleanup story — so getting it right early avoids a cascade of revisions later.


### PR DESCRIPTION
Adds `docs/stateful-agent-design/memory-aware-tools-analysis.md` — a review of the discussion captured in `memory-aware-tools-idea.md` (between Fran and Claude Sonnet 4.6) about replacing the current file-centric memory API with a memory-aware tools design.

The analysis is intended as input for the next conversation that will actually rewrite the `stateful-agent-design.md` document and its chapter files. It surfaces:

- **Critical issues** that should be resolved before the rewrite: tool signatures that omit the handle parameter, the unspecified read-your-own-writes path through "invisible" branches, the underspecified wake-up-phase mechanism, the asserted-but-unspecified atomicity of block-plus-index updates, and the undefined behavior when the LLM skips `memory_start_conversation`.
- **Internal inconsistencies** in the discussion (the "entirely in-bridge" framing vs. the threaded handle, three different statements of `memory_start_conversation`'s return value, the conflation of two separable improvements under one "memory-aware tools" label, an overstated rejection of Option A, and an implicit collapse of episodic logs into "blocks").
- **Significant omissions** (the `memory_get_index` schema, append-time race semantics, the `summary` parameter's contract, index behavior when the block write branches, handle lifetime/cleanup, on-disk branch storage model).
- **Concerns and trade-offs** worth acknowledging in the rewrite (Option B's merge-quality cost, the "handle" name as a soft behavioral nudge rather than a guarantee, loss of the `branches_exist` signal, accidental handle collisions, residual SKILL complexity).
- **Positives worth preserving** explicitly so they don't get diluted in the rewrite.
- **Three structural recommendations** for the rewrite itself.

The single most important issue to settle before rewriting is **§2.2 (read-your-own-writes through invisible branches)** — the per-handle branch model that resolves it has cascading implications for on-disk layout, the wake-up algorithm, handle lifetime, and orphaned-branch cleanup.

No code or design files are modified by this PR. The intent is to land the review as a sibling document to `design-review.md`, then start the design rewrite in a fresh conversation that can consume both.