### PR TITLE
docs: Update Chapter 3 §3.2 Configuration to handle terminology + new params

### DIFF
--- a/docs/stateful-agent-design/stateful-agent-design-chapter3.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter3.md
@@ -107,10 +107,27 @@ run_command:
 memory:
   directory: "C:\\franl\\.claude-agent-memory"
 
-# Session tracking
-session:
-  id_length: 8                    # Length of generated session IDs (e.g., "ses-7ka2")
-  max_sessions: 20                # Cap on tracked sessions (oldest evicted when exceeded)
+# Handle tracking and lifetime
+# A handle is the opaque per-conversation identifier the bridge mints in
+# memory_start_conversation and that the LLM passes to every memory tool.
+handle:
+  id_length: 8                    # Length of generated handles, lowercase alphanumeric (e.g., "h7k3xy90")
+  retention_days: 60              # Handles that own no branches and have been inactive this long are
+                                  # evicted during memory_run_maintenance. A handle that owns any
+                                  # branch is never evicted, regardless of age (eviction would orphan
+                                  # its branch and break read-your-own-writes for that conversation).
+
+# Bridge state persistence
+# The bridge persists live handles, the per-handle branch map, and per-handle
+# read baselines so this state survives Claude Desktop restarts (the bridge
+# terminates whenever Claude Desktop closes). Written atomically on clean
+# shutdown and on debounced checkpoints during operation; loaded and reconciled
+# against the filesystem at startup.
+persistence:
+  state_file: "C:\\franl\\.claude-agent-memory\\.bridge-state.json"
+  checkpoint_interval_seconds: 5  # Debounce window for checkpoint writes during operation.
+                                  # A branch creation also forces an immediate checkpoint, since
+                                  # that is the most important state to not lose on a hard crash.
 
 # Branching (concurrent read-modify-write race resolution)
 branching:
@@ -137,6 +154,10 @@ func LoadConfig(path string) Config:
     // Validate:
     //   - async.sync_window_seconds < 30
     //   - memory.directory exists (or create it)
+    //   - handle.id_length >= 8 (shorter handles raise collision risk)
+    //   - handle.retention_days > 0
+    //   - persistence.state_file parent directory exists (or create it)
+    //   - persistence.checkpoint_interval_seconds > 0
     //   - logging.file parent directory exists
     //   - claude_cli.path is executable
     //   - run_command.shell is executable


### PR DESCRIPTION
Updates the §3.2 Configuration section of Chapter 3 to use the new "handle" terminology and to add the configuration parameters introduced by the memory-aware-tools redesign.

## Changes

**`session:` block → `handle:` block.** The example YAML config used the old session terminology. Replaced with a `handle:` block:
- `id_length: 8` — comment updated to describe 8-char lowercase alphanumeric handles (e.g., `h7k3xy90`), no `ses-` prefix, per design plan §3.4.
- `retention_days: 60` — the new handle-eviction window from design plan §3.7 (your 60-day value). The comment notes that a handle owning any branch is never evicted regardless of age.
- Dropped `max_sessions` — the hard count cap was deferred to v1.x per §3.7, so it doesn't belong in the v1 config.

**New `persistence:` block.** The §2.12 state-persistence decision introduced real configurable parameters that were missing from the config section:
- `state_file` — path to `.bridge-state.json`.
- `checkpoint_interval_seconds: 5` — debounce window for checkpoint writes, with a note that branch creation forces an immediate checkpoint.

**Config-loading validation pseudo-code** extended to validate `handle.id_length >= 8`, `handle.retention_days > 0`, `persistence.state_file` parent directory, and `persistence.checkpoint_interval_seconds > 0`.

## Scope note

This PR updates **only** the §3.2 Configuration section. The rest of Chapter 3 still uses the session-era terminology and tool names (`memory_session_start`, `safe_read_file`, `safe_write_file`, the session tracker, etc.). Migrating all of that is the full Chapter 3 rewrite, which is step 2 in the plan's work ordering (§5) and a much larger change. I kept this PR surgical so it's easy to review and doesn't pre-empt the larger rewrite. The result is a temporary terminology inconsistency *within* Chapter 3 (the config section says "handle," the rest says "session"), which the full rewrite will resolve.

## A note on the persistence config

You asked specifically about the handle retention parameter and the session→handle terminology. I also added the `persistence:` block because §2.12 is ratified and introduces concrete config knobs (state file path, checkpoint cadence) that the config section would otherwise be silently missing. If you'd rather defer the persistence config to the full Chapter 3 rewrite to keep this PR strictly scoped to what you asked, let me know and I'll pull it back out.