### PR TITLE
Design: multi-bridge concurrency for Claude Code support; shorten SKILL.md description to 200-char limit

### DIFF
--- a/docs/stateful-agent-design/stateful-agent-design-chapter11.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter11.md
@@ -15,6 +15,35 @@ This section contains all questions that were ever open, even if they are now re
 
     - *Current status (open, target v1.x):* For v1, the derived index is the search surface — `memory_get_index` returns every block's name, summary, and `updated_at`, and Claude selects blocks to load by scanning summaries. The summary contract (required for new blocks, ≤ 200 characters) exists partly to keep this scan effective. When summaries prove insufficient (anticipated at ~50+ blocks), a bridge-side `memory_search(handle, query, max_results)` tool is the planned remedy. Design requirements carried over and updated from OQ#13: (a) the tool takes the conversation handle like every other memory tool; (b) it searches base blocks *and*, for the calling handle, that handle's branches (preserving the per-handle consistent view) while never exposing other handles' branches; (c) results identify blocks by **name** with snippets — no file paths, no branch filenames; (d) it does not establish read baselines (search results are informational; a subsequent `memory_get_block` registers the read); and (e) it holds the mutex only long enough to snapshot the file list. Implementation options range from simple bridge-side text scan to the FTS5 index of [Chapter 9, Section 9.1](stateful-agent-design-chapter9.md#91-fts5-search-index-option-3).
 
+- **OQ#18: Reliability of start-of-conversation memory initialization** — The skill's
+  `description` instructs the agent to initialize memory at the start of every conversation, but a
+  conversation has been observed in which the description was present in the skill listing and
+  `memory_start_conversation` was nonetheless never called. The frontmatter `description` is
+  consulted to judge whether a skill is *relevant*; it is not a mechanism that guarantees an action
+  is *performed*. Contributing factors identified in that instance: the skill body (which contains
+  the explicit conversation-start protocol of
+  [Chapter 5, Section 5.3](stateful-agent-design-chapter5.md#53-conversation-lifecycle)) is only
+  loaded once the skill is judged relevant, so the directive that was actually in context was the
+  one-line description; the bridge's tools were presented as deferred definitions requiring a tool
+  search before they could be called; and a separate, non-deferred memory facility was available and
+  was used instead.
+
+    - *Current status (open):* Unresolved, and **not** addressed by the `description` shortening of
+      [Chapter 5, Section 5.7](stateful-agent-design-chapter5.md#57-frontmatter-constraints-and-portability),
+      which governs only the field's length. Two directions are worth evaluating. (a) *Make
+      initialization unnecessary rather than mandatory:* have any memory tool lazily mint a handle
+      when called without a valid one, converting a client-side compliance requirement into a
+      bridge-side invariant that holds regardless of agent behavior. This would interact with the
+      no-graceful-re-init decision of
+      [Chapter 3, Section 3.14](stateful-agent-design-chapter3.md#314-handle-management), which
+      deliberately chose error-and-recover, so the tradeoff must be re-examined rather than assumed.
+      (b) *Move the directive to an unconditionally-loaded channel* — `CLAUDE.md` for Claude Code,
+      user preferences or project instructions for Claude Desktop — leaving the `description` to do
+      only what descriptions do reliably, which is trigger discovery. A prerequisite for evaluating
+      either is **measurement**: the bridge currently records nothing that would distinguish "no
+      memory was needed" from "initialization never happened," so the compliance rate is not
+      observable. Instrumenting that is the first step.
+
 ### 11.2 Resolved Questions
 
 - **OQ#1: Race condition with memory writes** — MCP bridge tools `safe_write_file` and `safe_append_file` serialize file writes using a Go mutex, however this only prevents torn writes. It doesn't solve the problem where concurrent conversations race via read-modify-write.  For instance, if conversation A reads `core.md` and conversation B reads `core.md`, then after each is modified in-context, whichever conversation writes `core.md` last overwrites the other's changes.  Would it help to add a `safe_edit_file` tool that uses the same mutex?

--- a/docs/stateful-agent-design/stateful-agent-design-chapter3.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter3.md
@@ -33,6 +33,7 @@
   - [3.22 Logging](#322-logging)
   - [3.23 Error Handling](#323-error-handling)
   - [3.24 Graceful Shutdown](#324-graceful-shutdown)
+  - [3.25 Multi-Bridge Concurrency](#325-multi-bridge-concurrency)
 
 ## 3. MCP Bridge Server
 
@@ -1102,6 +1103,9 @@ eviction when **both** hold:
    60 days since its last memory tool call. Baselines for a handle idle that long are very
    unlikely to ever be consulted again.
 
+**Multi-bridge note:** when more than one MCP client is deployed, a bridge evicts only handles
+recorded in its *own* state file; see [Section 3.25.4](#3254-per-client-state-files).
+
 Cleanup runs as the final sweep of every `memory_run_maintenance` call
 ([Section 3.13](#313-tool-memory_run_maintenance)) — no separate timer, no background thread, the
 same user-controlled cadence as merging. Eviction removes the handle's entry from the in-memory
@@ -1225,7 +1229,13 @@ it.
 
 **Expected frequency:** branching only occurs when two conversations are active simultaneously
 *and* both modify the same target after overlapping reads. The typical usage pattern — one active
-conversation at a time — produces zero branches.
+conversation at a time — produces zero branches. This changes materially in a multi-client
+deployment; see [Section 3.25.8](#3258-effect-on-branching-and-merging).
+
+**Multi-bridge note:** the routing rules above gain a self-healing precondition when a branch file
+has been merged away by a peer bridge, and the signature compared during write routing gains a
+content hash. Both are specified in [Section 3.25](#325-multi-bridge-concurrency); the branching
+algorithm itself is unchanged.
 
 ### 3.16 Block File Format and Atomic Writes
 
@@ -1273,7 +1283,11 @@ write with an `index.md` write; the simpler invariant is easier to verify and to
 **Windows rename caveat:** `os.Rename` cannot atomically overwrite an existing file on all Windows
 filesystems. The v1-proven approach applies: remove the target if it exists, then rename — an
 acceptably tiny non-existence window given mutex-serialized, low-frequency writes. If true
-atomicity is needed later, the Windows `ReplaceFile` API can be called via `syscall`.
+atomicity is needed later, the Windows `ReplaceFile` API can be called via `syscall`. **In a
+multi-bridge deployment this becomes mandatory rather than optional, and temp file names gain a
+client-id component so that one bridge's startup sweeper cannot delete a peer's in-flight temp
+file** — see [Sections 3.25.6](#3256-atomic-replace-on-windows) and
+[3.25.7](#3257-temp-file-naming-and-the-startup-sweeper).
 
 **Crash recovery (startup sweeper):**
 
@@ -1341,6 +1355,10 @@ signature recorded for a read is consistent with the content returned; writes ac
 signature-compare-then-write sequences are atomic with respect to other conversations. A single
 mutex (rather than per-file locks) keeps the implementation trivial and deadlock-free; memory I/O
 is infrequent and sub-millisecond, so the serialization cost is negligible.
+
+**Both mutexes described above are process-local and therefore insufficient once more than one MCP
+client is deployed.** [Section 3.25.3](#3253-the-cross-process-memory-lock) layers an OS-level
+advisory file lock beneath them, retaining the in-process mutexes as the fast path.
 
 ### 3.18 Bridge State Persistence and Recovery
 
@@ -1418,6 +1436,12 @@ The bridge is never worse off than a lazy-adoption-only design, even in the corr
 **Eviction interplay:** the cleanup sweep of [Section 3.14](#314-handle-management) removes
 evicted handles from the in-memory map; they disappear from the state file at its next write.
 
+**Multi-bridge revision.** Everything above describes a single bridge owning a single
+`.bridge-state.json`. When two or more MCP clients are deployed, that file is partitioned into one
+file per client and the load-and-reconcile procedure is extended accordingly; a whole-file rewrite
+by one bridge would otherwise destroy the other's handles, branch map, and baselines. See
+[Section 3.25.4](#3254-per-client-state-files).
+
 ### 3.19 Error Response Convention
 
 Traditional programming APIs tended toward terse, machine-only error codes (`ENOENT`) because the
@@ -1483,6 +1507,7 @@ situations are identified):
 | `SUMMARY_REQUIRED` | `memory_write_block` called for a new block without a `summary` argument |
 | `SUMMARY_TOO_LONG` | `summary` exceeds the configured length cap |
 | `MAINTENANCE_IN_PROGRESS` | The bridge is currently consolidating memory; the operation should be retried shortly (returned instead of blocking on the merge mutex past an acceptable wait) |
+| `MEMORY_BUSY` | Another memory operation is holding memory I/O longer than the configured wait; retry shortly. In a multi-client deployment this includes contention with a peer bridge ([Section 3.25.3](#3253-the-cross-process-memory-lock)) |
 | `INTERNAL_ERROR` | Catch-all; the message stays generic; details go to the server log |
 
 **Schema-validation errors:** if MCP itself rejects a call (e.g., the required `handle` parameter
@@ -1747,4 +1772,245 @@ func main():
     log.Info("Stdin EOF detected, killing %d active jobs", jobManager.ActiveCount())
     jobManager.KillAll()  // calls Process.Kill() on all running subprocesses
     os.Exit(0)
+```
+
+### 3.25 Multi-Bridge Concurrency
+
+Every MCP client that registers the bridge spawns its **own** copy of the binary as a stdio child
+process. Supporting Claude Code alongside Claude Desktop ([Section 7.8](stateful-agent-design-chapter7.md#78-claude-code-deployment))
+therefore means two or more bridge processes running simultaneously against a single shared memory
+root. Nothing about the MCP protocol makes those processes aware of one another: each has its own
+handle map, its own mutexes, and its own view of what is on disk.
+
+This section defines what must change for that to be correct. It is written as a delta against
+Sections 3.14–3.18, which describe the single-bridge behavior; those sections remain accurate for
+a one-client deployment, and each now carries a pointer here.
+
+#### 3.25.1 What the Existing Design Already Gets Right
+
+It is worth stating plainly what does *not* need to change, because it is more than one might
+expect, and it constrains how invasive the fix should be.
+
+- **Branch ownership never crosses processes.** A branch belongs to exactly one handle, a handle
+  belongs to exactly one conversation, and a conversation lives inside exactly one client. Two
+  bridges therefore never write the same branch file. The flat peer-branch storage model of
+  [Section 3.15](#315-per-handle-branching-and-race-detection) survives multi-bridge operation
+  unchanged.
+- **Race detection already consults the filesystem, not memory.** The signature comparison reads
+  the base file's current on-disk state rather than a cached in-process value, so it observes
+  writes made by a *peer* bridge exactly as it observes writes made by another conversation in
+  the same bridge. The detection mechanism is already cross-process; only its atomicity is not.
+- **Branch filenames embed the owning handle.** Lazy adoption ([Section 3.18](#318-bridge-state-persistence-and-recovery))
+  reconstructs the handle→branch association from the filesystem alone, which means a bridge can
+  correctly interpret branch files created by a peer it knows nothing about.
+- **Maintenance already enumerates branches regardless of handle liveness.** The merge process of
+  [Section 3.17](#317-merge-process-and-merge-mutex) folds in every peer branch of a block found
+  on disk, so a merge run from one client correctly incorporates branches created by another.
+
+The consequence is that the *algorithms* are sound and the *serialization* is not. The changes
+below are almost entirely about locking, state-file ownership, and a few file-naming details.
+
+#### 3.25.2 What Breaks Without Changes
+
+| Mechanism | Single-bridge assumption | Multi-bridge failure |
+|---|---|---|
+| Process-wide memory mutex ([3.17](#317-merge-process-and-merge-mutex)) | Compare-signature-then-write is atomic | Classic TOCTOU: bridge A reads a matching signature, bridge B writes the base, bridge A writes the base. The update is lost **and no branch is created** — the exact silent overwrite branching exists to prevent |
+| Merge mutex ([3.17](#317-merge-process-and-merge-mutex)) | A merge is isolated from all memory I/O | A peer bridge reads partial merge state, or creates a new branch of a block mid-merge that the merge then deletes |
+| `.bridge-state.json` whole-file rewrite ([3.18](#318-bridge-state-persistence-and-recovery)) | One writer | Last-writer-wins on the *whole file*: one bridge's entire handle set, branch map, and read baselines are destroyed by the other's next checkpoint |
+| Startup temp sweeper ([3.16](#316-block-file-format-and-atomic-writes)) | Only this bridge's temp files exist | A starting bridge deletes a peer's in-flight `*.tmp.*` file mid-write, corrupting that write |
+| Remove-then-rename window ([3.16](#316-block-file-format-and-atomic-writes)) | Window is covered by the memory mutex | A peer read lands in the window and observes the block as nonexistent |
+| Handle eviction ([3.14](#314-handle-management)) | The bridge knows every live handle | A bridge evicts a handle that is live in a peer, orphaning branches or forcing a spurious `INVALID_HANDLE` |
+| Handle minting collision check ([3.8](#38-tool-memory_start_conversation)) | One map holds all handles | Two bridges can mint the same handle; astronomically unlikely, but the check no longer covers the space it claims to |
+
+#### 3.25.3 The Cross-Process Memory Lock
+
+All memory file I/O is serialized across bridge processes by an **OS-level advisory lock** taken on
+a dedicated zero-length file, `.bridge-lock`, in the memory root.
+
+The choice of an OS lock over a hand-rolled lockfile (one containing a PID, say) is deliberate and
+load-bearing: **the operating system releases the lock automatically when the holding process
+terminates, for any reason, including a hard kill or a crash.** That single property eliminates the
+entire category of stale-lock recovery logic — no PID liveness probes, no lock expiry heuristics,
+no "is that process really dead?" ambiguity. Given that these bridges are killed routinely (Claude
+Desktop terminates its child on close, per [Section 3.24](#324-graceful-shutdown)), crash-safety by
+construction is worth far more here than it would be in a long-lived server.
+
+Implementation:
+
+- **Windows:** `LockFileEx` with `LOCKFILE_EXCLUSIVE_LOCK`, taken on a fixed byte range of
+  `.bridge-lock`, via `golang.org/x/sys/windows`.
+- **POSIX:** `flock(2)` with `LOCK_EX`, via `golang.org/x/sys/unix`. Included because portability
+  costs little here and the system may be packaged for general release; `flock` is preferred over
+  POSIX record locks (`fcntl`), whose release-on-any-close-in-the-process semantics are a
+  well-known hazard.
+
+**Two-level locking.** The existing in-process `sync.Mutex` is retained and acquired *first*, then
+the file lock. The in-process mutex is cheap and serializes this bridge's own goroutines without
+touching the filesystem; the file lock is acquired only once contention has already been resolved
+locally. The ordering is fixed and uniform, so no deadlock is possible. Release is in reverse
+order.
+
+**Scope of the lock.** It is held for the whole of any sequence that must be atomic with respect to
+peers:
+
+1. The read path, from signature capture through content return, so the baseline recorded for a
+   read matches the content actually returned.
+2. The write path, from signature comparison through the atomic replace, so the branch/no-branch
+   decision cannot be invalidated between the decision and the write.
+3. The entire duration of each block's merge ([Section 3.17](#317-merge-process-and-merge-mutex)).
+
+**Acquisition timeout.** A new config key, `locking.acquire_timeout_seconds` (default 10), bounds
+how long a bridge waits. On expiry the tool returns `MEMORY_BUSY`
+([Section 3.19](#319-error-response-convention)) rather than hanging — a caller blocked behind a
+peer's long-running merge gets a clear, retryable error instead of a stalled conversation. The
+timeout must exceed the longest expected merge, which is itself bounded by the per-call merge cap
+of [Section 3.13](#313-tool-memory_run_maintenance).
+
+Per the abstraction-discipline rule of [Section 3.19](#319-error-response-convention), neither the
+code nor its message may reveal that locking or multiple bridge processes exist. `MEMORY_BUSY`
+carries a message such as *"Memory is busy; please retry in a moment"* — true at the block
+abstraction, and actionable without exposing anything internal.
+
+#### 3.25.4 Per-Client State Files
+
+The single `.bridge-state.json` is replaced by **one state file per client**:
+
+```
+.bridge-state-<client-id>.json
+```
+
+`client-id` is supplied by a new `--client-id` command-line flag (equivalently `client.id` in
+`bridge-config.yaml`), defaulting to `desktop` for backward compatibility. It must be
+filename-safe (`[a-z0-9-]{1,32}`) and, critically, **stable across restarts of the same client** —
+it identifies the client, not the process instance. A bridge launched by Claude Desktop uses
+`desktop`; one launched by Claude Code uses `claude-code`.
+
+This partitioning is what makes checkpointing safe *without* taking the memory lock. Handles are
+owned by exactly one client, so the per-client files have disjoint contents and exactly one writer
+each. The debounced checkpoint of [Section 3.18](#318-bridge-state-persistence-and-recovery) fires
+every few seconds; forcing it to contend with memory I/O on the shared lock would be both wasteful
+and a source of avoidable latency. Partitioning removes the contention entirely rather than
+managing it.
+
+**Startup load and reconcile**, revised:
+
+1. Load this bridge's own `.bridge-state-<client-id>.json`.
+2. Reconcile it against the filesystem exactly as before: drop branch-map entries whose branch
+   files no longer exist. Note that in a multi-bridge deployment this case is no longer rare —
+   a peer's maintenance run legitimately merges away and deletes this client's branches.
+3. Read peer state files (`.bridge-state-*.json`, excluding this client's) **read-only**, solely
+   to learn which handles are owned elsewhere. This informs eviction and handle minting. A bridge
+   never writes a peer's file.
+4. Run lazy adoption as before, over branch files not represented in *any* loaded state.
+
+**Migration.** On first startup, a bridge finding a legacy `.bridge-state.json` renames it to
+`.bridge-state-<client-id>.json` using its own client id, then proceeds. Since the legacy file
+could only have been produced by a single-client deployment, attributing it to the current client
+is correct in every realistic case, and harmless otherwise (the worst outcome is lost baselines,
+which degrades exactly as a missing state file already does).
+
+**Eviction, revised.** A bridge evicts only handles present in its *own* state file. It never
+evicts a handle it learned about from a peer's file, because it cannot observe that handle's
+activity and has no authority over its lifetime. The eligibility rules of
+[Section 3.14](#314-handle-management) are otherwise unchanged.
+
+**Handle minting, revised.** The collision check of [Section 3.8](#38-tool-memory_start_conversation)
+consults the union of this bridge's handles and those read from peer state files. Minting is rare
+(once per conversation), so performing it under the memory lock with a fresh re-read of peer files
+costs nothing measurable and restores the guarantee the check is supposed to provide.
+
+#### 3.25.5 Strengthening the Read Baseline Signature
+
+`Signature` gains a content hash:
+
+```go
+type Signature struct {
+    ModTime time.Time
+    Size    int64
+    Hash    string  // first 16 hex chars of SHA-256 over the file's bytes
+}
+```
+
+Comparison uses `Hash` as the authoritative discriminator; `ModTime` and `Size` are retained for
+cheap early-out and for human debugging.
+
+The motivation is that ModTime-plus-size is a materially weaker discriminator once independent
+processes are writing. Windows filesystem timestamp granularity, combined with a rewrite that
+happens to produce the same file size — hardly exotic for prose blocks edited in place — yields a
+false "signatures match," which the write path reads as "no race" and resolves by overwriting the
+base. That is precisely the silent data loss branching exists to prevent, so paying a SHA-256 over
+a file that is at most a few tens of kilobytes, on operations that occur at conversational
+frequency, is an obviously good trade.
+
+#### 3.25.6 Atomic Replace on Windows
+
+The remove-then-rename fallback described in [Section 3.16](#316-block-file-format-and-atomic-writes)
+is **no longer acceptable**. Its justification was that the non-existence window is tiny and
+mutex-serialized; with peers holding no such mutex, a concurrent read can land inside the window
+and observe a block as missing, which the caller would interpret as "this block does not exist."
+
+The bridge must therefore use a genuinely atomic replace: `MoveFileEx` with
+`MOVEFILE_REPLACE_EXISTING`, or `ReplaceFile` where its additional semantics are wanted, via
+`golang.org/x/sys/windows`. Both are atomic on NTFS. Section 3.16 already anticipated this as a
+future refinement; multi-bridge support is what makes it mandatory.
+
+#### 3.25.7 Temp File Naming and the Startup Sweeper
+
+Temp file names gain the client id:
+
+```
+<name>.md.tmp.<client-id>.<random>
+```
+
+The startup sweeper deletes only orphan temp files carrying **its own** client id and older than
+the existing age threshold. A peer's in-flight temp file is neither matched nor removed. Temp files
+belonging to a client that is no longer deployed persist harmlessly until that client next starts;
+they are small, and deleting a peer's file cannot be made safe without a liveness check the lock
+design deliberately avoids.
+
+#### 3.25.8 Effect on Branching and Merging
+
+Branching needs no algorithmic change. This is the payoff from
+[Section 3.25.1](#3251-what-the-existing-design-already-gets-right): the branch/no-branch decision
+was already made against on-disk state, so restoring atomicity around it — via the cross-process
+lock — plus strengthening the signature is sufficient to make it correct across bridges. The branch
+map, the naming convention, read-your-own-writes, and the no-branches-of-branches rule all carry
+over verbatim.
+
+Merging requires one genuine addition. Step 7 of [Section 3.17](#317-merge-process-and-merge-mutex)
+clears branch-map entries `(*, B)` so that every handle routes back to the merged base. A bridge
+can do that for its own handles, but it **cannot** write a peer's state file, so a peer's handles
+would retain branch-map entries pointing at files the merge has deleted.
+
+The fix is to make branch-map entries **self-healing at routing time** rather than requiring the
+merging bridge to reach into peer state. The read and write routing rules of
+[Section 3.15](#315-per-handle-branching-and-race-detection) gain a precondition:
+
+> If the branch map has an entry for `(H, B)` but the referenced branch file no longer exists,
+> the branch was merged away by a peer. Drop the entry, fall back to the base file, and reset
+> `H`'s baseline for `B` on the next read.
+
+This keeps every bridge the sole writer of its own state while guaranteeing that a merge performed
+anywhere becomes visible everywhere, on next use, with no coordination. It also subsumes the
+startup reconcile step (item 2 of [Section 3.25.4](#3254-per-client-state-files)) as a runtime
+invariant rather than a startup-only sweep, which is strictly stronger.
+
+**Expected frequency, revised.** [Section 3.15](#315-per-handle-branching-and-race-detection) notes
+that the typical one-conversation-at-a-time pattern produces zero branches. With two clients in
+regular use — particularly Claude Code, where long agentic sessions may run while a Desktop
+conversation is also active — simultaneous conversations become common rather than exceptional.
+Branching should be expected to occur in normal operation, and the merge path becomes a routine
+code path rather than a rarely-exercised one. It must be tested accordingly
+([Chapter 8](stateful-agent-design-chapter8.md#8-testing-strategy)).
+
+#### 3.25.9 Configuration Summary
+
+```yaml
+# Client identity (see Section 3.25.4)
+client:
+  id: desktop            # or claude-code; stable per client, [a-z0-9-]{1,32}
+
+# Cross-process locking (see Section 3.25.3)
+locking:
+  acquire_timeout_seconds: 10
 ```

--- a/docs/stateful-agent-design/stateful-agent-design-chapter5.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter5.md
@@ -14,12 +14,18 @@
   - [5.4 Memory Write Triggers](#54-memory-write-triggers)
   - [5.5 Memory Read Triggers](#55-memory-read-triggers)
   - [5.6 Reconciliation with Layer 1](#56-reconciliation-with-layer-1)
+  - [5.7 Frontmatter Constraints and Portability](#57-frontmatter-constraints-and-portability)
 
 ## 5. Memory Skill
 
 The memory-aware tool redesign makes this the most-simplified chapter of the design. The v1 skill had to teach Claude the storage model: file paths, session IDs, branch annotations, index maintenance, race recovery, and a list of forbidden tools. All of that is now enforced by the bridge in code. What remains for the skill is the part that genuinely requires judgment: **when** to read and write memory, **what** to store, and **how** to structure it. The skill teaches lifecycle and content quality; the bridge guarantees storage correctness.
 
 ### 5.1 Skill Packaging
+
+The memory skill is installed in one of two ways, depending on the client
+([Chapter 7](stateful-agent-design-chapter7.md#7-build-and-deployment)). Claude Code reads skills
+directly from the filesystem, so installation there is a file copy and the packaging rules below
+do not apply. Claude Desktop takes an uploaded archive, described here.
 
 The memory skill is a Claude Desktop skill packaged as a `.zip` file. Claude Desktop's uploader expects the archive to contain a single top-level *folder* whose name matches the skill's `name`, with `SKILL.md` inside it — not a bare `SKILL.md` at the archive root (a mismatched or missing folder is a documented upload-failure cause). The skill contains no scripts (all operations use the bridge's MCP tools). Upload it via Claude Desktop > Customize > Skills > "+" > "Upload a skill". Keep the `.zip` extension; `.skill` is only the extension Claude Desktop produces when you *download* an existing skill.
 
@@ -33,12 +39,12 @@ stateful-memory.zip
 
 ### 5.2 SKILL.md Content
 
-The SKILL.md below is the complete skill instruction file. It is the primary artifact that guides Claude's memory behavior. Note its brevity relative to the v1 skill: there are no file paths, no session-ID bookkeeping, no branch-handling instructions, and no index-maintenance rules — the bridge owns all of that. The file begins with YAML frontmatter — `name` and `description` — which Claude Desktop uses to index the skill and to decide when to invoke it; the `description` in particular must convey that the skill applies at the start of every conversation and whenever durable context is recalled or stored.
+The SKILL.md below is the complete skill instruction file. It is the primary artifact that guides Claude's memory behavior. Note its brevity relative to the v1 skill: there are no file paths, no session-ID bookkeeping, no branch-handling instructions, and no index-maintenance rules — the bridge owns all of that. The file begins with YAML frontmatter — `name` and `description` — which the client uses to index the skill and to decide when to invoke it; the `description` in particular must convey that the skill applies at the start of every conversation and whenever durable context is recalled or stored. The `description` is held to a 200-character budget for portability reasons set out in [Section 5.7](#57-frontmatter-constraints-and-portability); that budget is why it names no individual memory tools. The tool names live in the body below, which is loaded in full before any memory tool is called, so nothing is lost by omitting them from the frontmatter.
 
 ```markdown
 ---
 name: stateful-memory
-description: Persistent memory that survives across conversations, accessed through the bridge's memory tools. Use it at the START of every conversation to load durable context about the user, their projects, and shared history (memory_start_conversation, memory_get_core, memory_get_index, memory_get_block), and DURING the conversation to record or update that context as it emerges (memory_write_core, memory_write_block, memory_append_block, memory_append_episodic). Invoke whenever you need to recall what you know about the user or persist anything worth remembering next time.
+description: Persistent memory across conversations. Use at the START of every conversation to load user, project, and history context, and DURING it to record durable facts, decisions, and updates.
 ---
 
 # Stateful Agent Memory Skill
@@ -268,3 +274,53 @@ spawn_agent(
 **Step 3:** The primary agent applies fixes:
 - **Layer 1 fixes:** Add steering edits via the `memory_user_edits` tool. These are incorporated by Anthropic's nightly regeneration (~24-hour lag).
 - **Layer 2 fixes:** Update memory via `memory_write_core` / `memory_write_block` (immediate effect).
+
+### 5.7 Frontmatter Constraints and Portability
+
+The `description` field is subject to **three different documented limits**, depending on how the
+skill reaches the agent. Getting this wrong is a silent failure, so the constraints are recorded
+here rather than left to be rediscovered.
+
+| Surface | `name` | `description` | Nature of the limit |
+|---|---|---|---|
+| Agent Skills specification / Claude API skill upload | 64 chars | **1024 chars** | Hard validation; the Create Skill endpoint rejects a bundle that exceeds it |
+| Claude.ai skill upload (including Claude Desktop, which is a Claude.ai client) | 64 chars | **200 chars** | Documented product limit, tighter than the specification |
+| Claude Code (filesystem-installed skills) | 64 chars | No separate documented cap beyond the specification's 1024 | Subject instead to a context budget across the whole skill listing, which can drop or truncate descriptions when many skills are installed |
+
+**Design decision: the `description` targets 200 characters or fewer.**
+
+The reasoning is that 200 is the tightest documented ceiling among the surfaces this system may
+plausibly be delivered through, and a description authored to the 1024-character specification
+limit cannot be uploaded through the Claude.ai Skills UI without being edited first. Since the
+Stateful Agent system may eventually be packaged for general release rather than remaining a
+personal deployment, the skill must install unmodified on every surface. Designing to the tightest
+ceiling costs a little expressiveness once; designing to the loosest costs a manual edit on every
+constrained install, forever.
+
+**On enforcement.** In July 2026 the 570-character `description` this design previously specified
+was observed reaching a Claude.ai session's skill listing fully intact, so the 200-character limit
+is evidently not enforced uniformly on every upload path today. That observation is deliberately
+*not* treated as license to exceed it. Non-enforcement is not a contract: it can be tightened at
+any time, and — see below — the failure it would produce is invisible.
+
+**Why truncation is the dangerous failure mode.** A description that exceeds a limit is not
+rejected with an error the author will notice; it is silently cut, from the end. The trailing
+content of a description is where "and use it when…" trigger vocabulary conventionally sits, so
+truncation removes precisely the part that governs invocation while leaving the skill visibly
+installed and apparently healthy. The skill simply stops being selected in cases it used to cover,
+with nothing anywhere reporting why. Two consequences follow:
+
+1. **Front-load the triggers.** The earliest words must carry the conditions under which the skill
+   applies, so that any truncation removes elaboration rather than meaning.
+2. **Prefer trigger coverage to elegance.** Within the budget, spend characters on the vocabulary a
+   request is likely to use, not on describing the mechanism. The mechanism is what the body is
+   for.
+
+**Known limitation.** The frontmatter `description` is metadata consulted to decide whether a skill
+is *relevant*, which is not the same as an instruction that is reliably *executed*. A conversation
+in which the skill's start-of-conversation directive was present in the description but
+`memory_start_conversation` was nonetheless never called has been observed. Shortening the
+description neither causes nor cures this; the reliability of start-of-conversation initialization
+is tracked separately as an open question
+([Chapter 11](stateful-agent-design-chapter11.md#11-open-questions)) and is out of scope for this
+section, which governs only the field's length and content.

--- a/docs/stateful-agent-design/stateful-agent-design-chapter7.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter7.md
@@ -16,6 +16,8 @@
   - [7.5 Initial Memory Seeding](#75-initial-memory-seeding)
   - [7.6 Skill Installation](#76-skill-installation)
   - [7.7 CLAUDE.md Update](#77-claudemd-update)
+  - [7.8 Claude Code Deployment](#78-claude-code-deployment)
+  - [7.9 Running Multiple Clients Concurrently](#79-running-multiple-clients-concurrently)
 
 ## 7. Build and Deployment
 
@@ -66,6 +68,11 @@ Add the bridge server entry:
 
 The Desktop App will launch the bridge as a subprocess on startup, communicating via stdio.
 
+If any other MCP client will also run the bridge against the same memory root, add
+`"--client-id", "desktop"` to `args` — see [Section 7.9](#79-running-multiple-clients-concurrently)
+and [Chapter 3, Section 3.25.4](stateful-agent-design-chapter3.md#3254-per-client-state-files). The
+value defaults to `desktop`, so a Desktop-only deployment may omit it.
+
 **Note:** The Filesystem extension does **not** appear in `claude_desktop_config.json` and should **not** be added there. It is a first-party Claude Desktop extension developed by Anthropic and distributed through Claude Desktop's built-in extensions gallery (Settings > Extensions). It is installed, enabled, and configured entirely through the Claude Desktop UI — not via the config JSON file. Claude Desktop manages its configuration for first-party extensions through a separate internal store. See the resolution of Open Question #6 for details.
 
 ### 7.3 Filesystem Extension Configuration
@@ -114,3 +121,93 @@ Alternatively, ask Claude in an initial conversation to seed the memory from its
 ### 7.7 CLAUDE.md Update
 
 Replace the current `C:\Users\flitt\.claude\CLAUDE.md` with the lean sub-agent-optimized version described in [Section 6.5](stateful-agent-design-chapter6.md#65-claudemd-recommendations) and the proposal. Move credentials to environment variables. Move service-specific instructions to `spawn_agent` system_prompt parameters.
+
+### 7.8 Claude Code Deployment
+
+Claude Code is a supported client alongside Claude Desktop. It acts as an MCP client over the same
+stdio transport, so **the bridge binary requires no changes** to run under it; what differs is
+registration, skill installation, and the concurrency configuration of
+[Section 7.9](#79-running-multiple-clients-concurrently).
+
+**Register the bridge.** Claude Code stores MCP server configuration at three scopes: `local`
+(private to you, tied to one project), `project` (`.mcp.json` at the repository root, intended to
+be committed and shared), and `user` (global across all your projects). Memory is a personal,
+cross-project facility, so `user` scope is the correct choice — a project-scoped registration would
+make memory available only inside one repository, and a committed `.mcp.json` would publish a
+machine-specific absolute path:
+
+```bash
+claude mcp add --transport stdio --scope user mcp-bridge \
+  -- C:\franl\.claude-agent-memory\bin\mcp-bridge\mcp-bridge.exe \
+     --config C:\franl\.claude-agent-memory\bridge-config.yaml \
+     --client-id claude-code
+```
+
+The `--` separates Claude Code's own flags from the command line handed to the server. User-scope
+registration is written to `~/.claude.json`; note that this file is per-machine and is not
+synchronized across machines, so the command must be run once on each machine where the bridge is
+deployed.
+
+Verify with `claude mcp list`, or `/mcp` inside a session, which also reports connection status.
+
+**Install the skill.** Claude Code reads skills from the filesystem rather than from an uploaded
+archive, so there is no zip step and no upload step:
+
+```bash
+mkdir -p ~/.claude/skills/stateful-memory
+cp SKILL.md ~/.claude/skills/stateful-memory/
+```
+
+The directory name must match the skill's `name` frontmatter field (`stateful-memory`). The same
+`SKILL.md` authored per [Chapter 5, Section 5.2](stateful-agent-design-chapter5.md#52-skillmd-content)
+is used verbatim for both clients — this is the practical payoff of holding the `description` to
+the tightest documented limit ([Section 5.7](stateful-agent-design-chapter5.md#57-frontmatter-constraints-and-portability)):
+one artifact, no per-client variants to keep in sync.
+
+**Two behavioral differences worth knowing.**
+
+- **Tool definitions may be deferred.** Claude Code enables tool search by default, which defers
+  MCP tool definitions so that registering additional servers costs little context. A deferred tool
+  is not directly callable until it has been searched for, which weakens the affordance to invoke a
+  memory tool spontaneously. This interacts with the initialization-reliability question recorded
+  as OQ#18 ([Chapter 11](stateful-agent-design-chapter11.md#111-remaining-open-questions)).
+- **Sub-agents cannot reach the bridge.** Claude Code sub-agents do not inherit the parent session's
+  MCP server connections, so a sub-agent spawned by Claude Code has no memory access. This is
+  consistent with — and independently enforces — the design's existing rule that sub-agents never
+  write to memory ([Chapter 6, Section 6.6](stateful-agent-design-chapter6.md#66-sub-agent-memory-access-rules)),
+  but it also means sub-agents cannot *read* memory under Claude Code, so any context a sub-agent
+  needs must be passed explicitly in its prompt.
+
+### 7.9 Running Multiple Clients Concurrently
+
+Each MCP client spawns its own instance of the bridge binary. Deploying both Claude Desktop and
+Claude Code therefore means two bridge processes sharing one memory root, which requires the
+multi-bridge provisions of
+[Chapter 3, Section 3.25](stateful-agent-design-chapter3.md#325-multi-bridge-concurrency).
+
+Deployment requirements:
+
+1. **Every client must pass a distinct, stable `--client-id`.** Two clients sharing an id will
+   overwrite each other's state file; a client whose id changes between launches will orphan its
+   own handles, branch map, and read baselines on every restart. Use `desktop` and `claude-code`.
+2. **All clients must point at the same memory root**, via the same `bridge-config.yaml` or
+   equivalent configuration. Two bridges with different memory roots are simply two independent
+   memory systems, which is a supported configuration but not a shared one.
+3. **All clients should run the same bridge build.** The cross-process lock, the state-file naming
+   convention, the temp-file naming convention, and the signature format are all shared on-disk
+   contracts. A mixed-version deployment where one bridge predates
+   [Section 3.25](stateful-agent-design-chapter3.md#325-multi-bridge-concurrency) provides *no*
+   safety at all, because the older binary takes no lock — the newer one would be serializing
+   against a peer that ignores serialization entirely.
+
+**Migration from a single-client deployment.** No manual step is required. On first startup the
+bridge renames an existing `.bridge-state.json` to `.bridge-state-<client-id>.json`
+([Chapter 3, Section 3.25.4](stateful-agent-design-chapter3.md#3254-per-client-state-files)).
+Perform this first startup with the Desktop client (or whichever client owns the existing state)
+before registering the second client, so the legacy state is attributed to the right one.
+
+**Expect branches.** With one client, simultaneous conversations were the exception and branching
+was effectively never triggered. With two clients — especially given that Claude Code sessions can
+run for a long time while a Desktop conversation is also active — concurrent modification becomes
+ordinary. `memory_run_maintenance` moves from a rarely-needed housekeeping call to a routine part
+of the workflow, and should be run correspondingly more often.

--- a/docs/stateful-agent-design/stateful-agent-design.md
+++ b/docs/stateful-agent-design/stateful-agent-design.md
@@ -14,6 +14,7 @@
   - [2.1 Component Diagram](#21-component-diagram)
   - [2.2 Data Flow](#22-data-flow)
   - [2.3 What the Bridge Does NOT Do](#23-what-the-bridge-does-not-do)
+  - [2.4 Supported Client Environments](#24-supported-client-environments)
 - [3. MCP Bridge Server](stateful-agent-design-chapter3.md)
 - [4. Memory System (Layer 2)](stateful-agent-design-chapter4.md)
 - [5. Memory Skill](stateful-agent-design-chapter5.md)
@@ -244,6 +245,34 @@ The bridge is deliberately minimal. It does **not** provide:
 This keeps the initial bridge focused: twelve tool handlers, a write mutex, the handle map with read baselines and branch routing, the derived-index builder, the state persistence layer, the maintenance/merge engine, the async executor, and the job lifecycle manager.
 
 ---
+
+### 2.4 Supported Client Environments
+
+The component diagram above shows Claude Desktop, which was the original and for some time the only
+client. The system supports two:
+
+| Client | Bridge transport | Skill installation | Notes |
+|---|---|---|---|
+| Claude Desktop | stdio, spawned as a child process | Uploaded `.zip` archive | The `description` frontmatter field is subject to a 200-character product limit ([Chapter 5, Section 5.7](stateful-agent-design-chapter5.md#57-frontmatter-constraints-and-portability)) |
+| Claude Code | stdio, spawned as a child process | Filesystem copy into `~/.claude/skills/` | Registered at user scope; MCP tool definitions may be deferred, and sub-agents do not inherit MCP connections |
+
+**The bridge binary is identical for both.** Nothing about the MCP interface differs between the
+clients; they are distinguished only by how they are configured
+([Chapter 7, Sections 7.2 and 7.8](stateful-agent-design-chapter7.md#7-build-and-deployment)) and by
+the `--client-id` value each passes.
+
+**Both may run at once.** Because each client spawns its own copy of the binary, concurrent use
+means two bridge processes against one memory root. The single-writer assumptions that the original
+design could safely make — a process-wide mutex serializing all memory I/O, one owner of
+`.bridge-state.json` — no longer hold in that configuration. The provisions that restore them are
+specified in [Chapter 3, Section 3.25](stateful-agent-design-chapter3.md#325-multi-bridge-concurrency)
+and their deployment requirements in
+[Chapter 7, Section 7.9](stateful-agent-design-chapter7.md#79-running-multiple-clients-concurrently).
+
+**A note on the diagram.** The diagram in [Section 2.1](#21-component-diagram) is drawn from the
+Claude Desktop perspective and has not been redrawn per-client. The Anthropic Filesystem extension
+shown there is a Claude Desktop feature specifically; Claude Code provides its own file access and
+does not use it. The bridge box and every memory tool in it apply unchanged to both clients.
 
 ## 3. MCP Bridge Server
 


### PR DESCRIPTION
Adds design coverage for two changes, both intended for implementation (deliberately **not** placed in Chapter 9, Future Enhancements).

## 1. Claude Code as a supported client, and multi-bridge concurrency

**New: Chapter 3, Section 3.25 — Multi-Bridge Concurrency.** Each MCP client spawns its own copy of the bridge binary, so supporting Claude Code alongside Claude Desktop means two processes against one memory root.

The good news, recorded in §3.25.1, is that more of the existing design survives than expected: branch ownership never crosses processes (a branch belongs to one handle, a handle to one conversation, a conversation to one client), race detection already compares against on-disk state rather than a cached value, branch filenames embed their handle so lazy adoption works on files a peer created, and maintenance already enumerates branches from disk regardless of handle liveness. **The algorithms are sound; only the serialization is not.** That is what keeps the delta small.

§3.25.2 tabulates the seven invariants that break. The load-bearing ones:

- The process-wide memory mutex no longer makes compare-signature-then-write atomic — a TOCTOU that produces a lost update *with no branch created*, which is precisely the silent overwrite branching exists to prevent.
- `.bridge-state.json` is rewritten whole-file, so one bridge's checkpoint destroys the other's entire handle set, branch map, and baselines.
- The startup temp sweeper deletes a peer's in-flight `*.tmp.*` file.

Resolutions (§3.25.3–.7): an OS-level advisory lock on `.bridge-lock` layered beneath the existing in-process mutexes — chosen specifically because the OS releases it on process death, eliminating all stale-lock recovery logic for processes that get killed routinely; per-client state files (`.bridge-state-<client-id>.json`) so checkpoints need no lock at all; a content hash added to the read baseline signature, since ModTime+size is a weak discriminator across processes; mandatory atomic replace on Windows; and client-scoped temp file names.

**On branching and merging specifically** (§3.25.8): branching needs no algorithmic change. Merging needs one addition — a merging bridge cannot clear branch-map entries in a peer's state file, so routing gains a self-healing precondition: a branch-map entry whose file no longer exists means the branch was merged away, so drop the entry and fall back to base. Every bridge stays the sole writer of its own state while a merge anywhere becomes visible everywhere. Also worth flagging: §3.15's "typical usage produces zero branches" no longer holds with two clients — branching and merging become routine code paths and need corresponding test coverage.

**New: Chapter 7, Sections 7.8 and 7.9** — Claude Code registration at user scope, filesystem skill installation, the two behavioral differences (deferred tool definitions; sub-agents don't inherit MCP connections, so they cannot even *read* memory under Claude Code), and the deployment requirements for concurrent operation. Note the mixed-version hazard in 7.9.3: a bridge predating §3.25 takes no lock, so a mixed deployment provides no safety whatsoever.

**New: Section 2.4** in the main document, summarizing both client environments.

## 2. SKILL.md `description` shortened to 185 characters

Was 570. Three different documented limits apply depending on delivery path — 1024 (Agent Skills spec / API), **200 (Claude.ai upload, including Claude Desktop)**, and no separate cap for filesystem-installed Claude Code skills beyond a listing-wide context budget. Targeting 200, the tightest, keeps one `SKILL.md` installable everywhere without a per-surface edit, which matters given the possibility of general release.

New Section 5.7 records the limits, the decision, and why truncation is the dangerous failure mode: it is silent, it cuts from the end, and the end is conventionally where trigger vocabulary lives — so the skill stays visibly installed while quietly ceasing to be selected.

§5.7 also records that a 570-character description was observed reaching a session's skill listing fully intact in July 2026, so the 200 limit is evidently not enforced uniformly today — explicitly noted as *not* a license to exceed it.

The tool-name enumeration is dropped from the description; it survives in the skill body, which loads before any memory tool is called.

## Judgment calls worth reviewing

- **Sections are appended, not inserted.** 3.25 follows 3.24, 5.7 follows 5.6, 7.8/7.9 follow 7.7. Inserting would renumber downstream sections and invalidate anchors referenced across every chapter. Cross-reference notes were added to 3.14–3.18 pointing forward to 3.25 instead. All internal anchors were verified to resolve.
- **OQ#18 was added to Chapter 11** (`Remaining Open Questions`) covering the start-of-conversation initialization reliability problem — the case where the description instructed initialization and `memory_start_conversation` was never called. This is a *third* item beyond the two requested, added because §5.7 needed somewhere to point when disclaiming that shortening the description does not fix it. **Strip it if you consider it out of scope**; the only dependent is one sentence in §5.7 and one in §7.8. The substantive suggestion inside it — make initialization unnecessary via lazy handle minting rather than mandatory — deliberately conflicts with the no-graceful-re-init decision in §3.14 and is flagged as needing re-examination rather than assumed.
- **`MEMORY_BUSY`** was chosen over a name like `MEMORY_LOCK_TIMEOUT` to respect §3.19's abstraction-discipline rule, which forbids leaking mutexes and internals into error surfaces.
- **The `mcp-bridge` repo's actual `SKILL.md` is unchanged.** This PR only updates the design spec, per the request. The corresponding edit to `skill/SKILL.md` in `fpl9000/mcp-bridge` is separate work.