### PR TITLE
Design: bundle core+index into memory_start_conversation; add Ch13 implementation-ordering appendix

### DIFF
--- a/docs/stateful-agent-design/stateful-agent-design-chapter13.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter13.md
@@ -1,0 +1,283 @@
+# Stateful Agent System: Detailed Design – Chapter 13
+
+**Version:** 1.0  
+**Date:** July 2026  
+**Author:** Claude Opus (with guidance from Fran Litterio, @fpl9000.bsky.social)  
+**Companion documents:**
+- [Stateful Agent System: Detailed Design](stateful-agent-design.md) — main design document, of which this is a part.
+- [Chapter 3: MCP Bridge Server](stateful-agent-design-chapter3.md) — the normative specification this appendix sequences.
+
+## Contents
+
+- [13. Appendix: Implementation Ordering for Branching and Merging](#13-appendix-implementation-ordering-for-branching-and-merging)
+  - [13.1 Purpose and Scope](#131-purpose-and-scope)
+  - [13.2 The Governing Constraint](#132-the-governing-constraint)
+  - [13.3 Two Kinds of Prerequisite](#133-two-kinds-of-prerequisite)
+  - [13.4 The Ordered Plan](#134-the-ordered-plan)
+  - [13.5 Milestone Boundaries and Stopping Points](#135-milestone-boundaries-and-stopping-points)
+  - [13.6 Dependency Summary](#136-dependency-summary)
+  - [13.7 Effect on Chapter 7 (Build and Deployment)](#137-effect-on-chapter-7-build-and-deployment)
+  - [13.8 Relationship to Multi-Bridge Concurrency (Section 3.25)](#138-relationship-to-multi-bridge-concurrency-section-325)
+
+---
+
+## 13. Appendix: Implementation Ordering for Branching and Merging
+
+### 13.1 Purpose and Scope
+
+The minimal Layer 2 build in `fpl9000/mcp-bridge` (the eight-tool, memory-only build scoped by that
+repository's `IMPLEMENTATION-PROMPT.md`) deliberately omits the invisible per-handle branching
+subsystem of [Section 3.15](stateful-agent-design-chapter3.md#315-per-handle-branching-and-race-detection)
+and the semantic merge process of [Section 3.17](stateful-agent-design-chapter3.md#317-merge-process-and-merge-mutex).
+In that build, writes are unconditional last-writer-wins.
+
+This appendix defines the order in which the omitted functionality should be added so that branching
+works correctly in the **single-bridge** case, which is the immediate goal. It is a sequencing
+document, not a specification: every item below is already specified normatively in Chapter 3, and
+this appendix only says *in what order* to implement those specifications and *why that order is
+forced*. Where an item's position in the order is non-obvious or counter-intuitive, the reasoning is
+given explicitly.
+
+Multi-bridge concurrency ([Section 3.25](stateful-agent-design-chapter3.md#325-multi-bridge-concurrency))
+is a later goal and is out of scope here except where a single-bridge step should be implemented in
+its multi-bridge-ready form to avoid rework; those cases are called out individually in
+[Section 13.8](#138-relationship-to-multi-bridge-concurrency-section-325).
+
+### 13.2 The Governing Constraint
+
+**No functionality is re-implemented.** Every piece of new code either (a) implements a Chapter 3
+specification that the minimal build left unimplemented, or (b) is functionality the minimal build
+*explicitly* marked as omitted (in a code comment referencing the relevant section or the
+`IMPLEMENTATION-PROMPT.md` scope). Nothing is redesigned in passing, and no working code is rewritten
+except where this appendix identifies it as **currently correct only under the no-branching
+assumption** — see [Section 13.3](#133-two-kinds-of-prerequisite).
+
+The practical test for the implementer: before writing any code for an item below, locate the
+Chapter 3 section it implements and the matching "deferred / omitted / not implemented in this build"
+marker in the current source. If both exist, the item is in scope as specified. If the source has no
+such marker — meaning the minimal build already implemented something in this area — stop and treat
+the difference as potential drift to be reconciled against the spec before proceeding, exactly as was
+done for the `memory_start_conversation` bundling deviation.
+
+### 13.3 Two Kinds of Prerequisite
+
+The prerequisites to branching fall into two categories, and the distinction matters because it
+determines whether an item is a pure addition or a modification of existing code.
+
+- **Additive (restore omitted spec structure).** The minimal build left a field, a map, or a code
+  path out entirely. Adding it back is pure construction against the spec and disturbs nothing that
+  currently works. Example: restoring `HandleState.Branches`.
+
+- **Corrective (currently correct only because branches don't exist).** The minimal build contains
+  code that is spec-compliant *for a build with no branches* and becomes spec-violating the moment
+  branch files can exist on disk or two handles can see different views. This code must change
+  **before** branching is switched on, or branching will be silently defeated by it. These are the
+  dangerous items, because they look finished. Each is flagged **[CORRECTIVE]** below.
+
+Treating a corrective item as though it were merely additive — building branching on top of it
+without changing it first — is the single most likely way for this work to produce subtle,
+hard-to-attribute memory corruption. The corrective items are therefore front-loaded in the order.
+
+### 13.4 The Ordered Plan
+
+Each step lists the Chapter 3 section it implements, its category, what it touches, and why it holds
+the position it does. Steps 1–5 are prerequisites; step 6 is branching itself; step 7 is merging.
+
+#### Step 1 — Add a content hash to the read-baseline signature **[CORRECTIVE]**
+
+- **Implements:** [Section 3.25.5](stateful-agent-design-chapter3.md#3255-strengthening-the-read-baseline-signature)
+  (the `Hash` field), applied here for a single-bridge reason rather than a multi-bridge one.
+- **Touches:** the `Signature` type and its `Equal` method; every site that computes a signature.
+- **Why first:** branching's entire branch/no-branch decision is the signature comparison. The
+  minimal build compares `ModTime` + `Size` only, and its own comment calls a content hash "a
+  possible v1.x upgrade" — optional under last-writer-wins, because a false "unchanged" there merely
+  produces a slightly stale `changed_since_last_read` flag. Under branching, the same false match
+  causes the write path to *suppress a branch that was required* and overwrite a concurrent
+  conversation's block — the precise data loss branching exists to prevent. On Windows especially, a
+  coarse filesystem timestamp combined with an in-place edit that preserves file size is a realistic
+  way to hit that false match. The hash must exist and be authoritative before any code consumes the
+  comparison's verdict to make a branch decision, so it is unconditionally first.
+
+#### Step 2 — Restore `HandleState.Branches` and persist it **[additive]**
+
+- **Implements:** [Section 3.15](stateful-agent-design-chapter3.md#315-per-handle-branching-and-race-detection)
+  (the per-handle branch map) and [Section 3.18](stateful-agent-design-chapter3.md#318-bridge-state-persistence-and-recovery)
+  (persisting it).
+- **Touches:** the `HandleState` struct (add `Branches map[string]string`); the persistence
+  serialization and load-and-reconcile path.
+- **Why here:** nothing can *record* a branch without the map, and the map must survive a bridge
+  restart or a mid-conversation bridge bounce orphans live branches (a handle would lose the pointer
+  to its own branch file and fall back to the base, silently discarding its divergent view). This is
+  pure restoration of omitted spec structure; it changes no behavior on its own, so it is safe to
+  land before the logic that uses it.
+
+#### Step 3 — Make the derived index branch-aware, and make its cache per-handle **[CORRECTIVE]**
+
+- **Implements:** [Section 3.15](stateful-agent-design-chapter3.md#315-per-handle-branching-and-race-detection)
+  index-assembly steps 2–3 (base files only; per-handle branch substitution) and the per-handle index
+  cache.
+- **Touches:** `assembleIndex` (exclude `*.branch-*` files from block enumeration); the index-read
+  path (substitute a handle's branch of a block for the base when the branch map has an entry); the
+  `IndexCache` type (from a single shared cache keyed on directory mtime to one cache per handle).
+- **Why here, and why corrective — two distinct problems:**
+  1. *Enumeration.* Once branch files live in the blocks directory, `assembleIndex`'s "every `*.md`"
+     walk will index them as if they were blocks, producing phantom index entries the LLM can see.
+     The exclusion must be in place before the first branch file can be created.
+  2. *Caching.* The minimal build's index cache is a **single shared** value invalidated on directory
+     mtime. Section 3.15 specifies **one cache per handle**, because under branching two handles
+     legitimately see *different* index views of the same directory. A shared cache would serve one
+     handle the view that includes another handle's branch — defeating branch isolation invisibly,
+     with no error. This is the subtler of the two and the reason the whole step is corrective: the
+     cache looks finished and is not, for a branched world.
+
+#### Step 4 — Implement branch filename production and parsing **[additive]**
+
+- **Implements:** [Section 3.15](stateful-agent-design-chapter3.md#315-per-handle-branching-and-race-detection)
+  filename convention: `<basename>.branch-<handle>-<ISO8601compact-UTC>.<ext>` (e.g.
+  `core.branch-h7k3xy90-20260520T142300Z.md`).
+- **Touches:** a small self-contained producer/parser module: build a branch filename from
+  `(basename, handle, now)`; recover the owning handle from a filename by glob/parse.
+- **Why here:** foundational and dependency-free, so it can be built and unit-tested in isolation at
+  any point in steps 1–4; it is placed just before the write-path wiring that first needs it. Two
+  correctness notes for the implementer: the timestamp is the **compact** UTC form
+  (`20260520T142300Z`), distinct from the *extended* form used in the index JSON — colons are illegal
+  in Windows filenames; and the producer must handle **both** `core.md` in the memory root and
+  `blocks/*.md`, because core branches too ([Section 3.9](stateful-agent-design-chapter3.md#39-tools-memory_get_core-and-memory_write_core)).
+
+#### Step 5 — Replace the Windows write with a genuinely atomic replace **[CORRECTIVE]**
+
+- **Implements:** [Section 3.25.6](stateful-agent-design-chapter3.md#3256-atomic-replace-on-windows),
+  promoted from the multi-bridge phase to here.
+- **Touches:** `atomicWriteFile` (replace the remove-then-rename fallback with `MoveFileEx` +
+  `MOVEFILE_REPLACE_EXISTING`, or `ReplaceFile`).
+- **Why here — a correction to where this was originally filed:** this refinement was placed in the
+  multi-bridge phase in the Section 3.25 work, on the assumption that the single-bridge memory mutex
+  fully covers the remove-then-rename non-existence window. That assumption fails once branching
+  exists *even in a single bridge*: the merge process (step 7) releases and reacquires around
+  per-block work, and branch read routing can interleave with a base write, so a reader can land in
+  the window and observe a block as non-existent — reporting `BLOCK_NOT_FOUND` for a block that
+  exists. It is cheaper and safer to make the replace truly atomic before branching than to debug an
+  intermittent phantom-missing-block report afterward. Hence it is a single-bridge prerequisite, not
+  a multi-bridge one.
+
+#### Step 6 — Wire race-routing into the write path: branching proper **[additive, but the payoff step]**
+
+- **Implements:** [Section 3.15](stateful-agent-design-chapter3.md#315-per-handle-branching-and-race-detection)
+  write routing.
+- **Touches:** the block/core write handlers. On a write, compare the writing handle's baseline for
+  the target against the target's current on-disk signature (now hash-backed, step 1). If they match,
+  write the base as today. If they differ, a concurrent conversation changed the base since this
+  handle last read it: write to a new branch file (step 4), record `(handle, block) → branch path` in
+  the branch map (step 2), and route this handle's subsequent reads/writes/index views of that block
+  to its branch (step 3). Reads gain the symmetric routing: a handle with a branch of B reads its
+  branch, not the base.
+- **Why here:** it consumes all five prerequisites and nothing else. After this step, last-writer-wins
+  is replaced by never-lose in the single-bridge case. **This is a coherent, shippable stopping
+  point** — see [Section 13.5](#135-milestone-boundaries-and-stopping-points).
+
+#### Step 7 — Implement the semantic merge: `memory_run_maintenance` **[additive — but drags in the sub-agent subsystem]**
+
+- **Implements:** [Section 3.17](stateful-agent-design-chapter3.md#317-merge-process-and-merge-mutex),
+  plus the `MAINTENANCE_IN_PROGRESS` error code
+  ([Section 3.19](stateful-agent-design-chapter3.md#319-error-response-convention)) and the ninth
+  registered tool.
+- **Touches:** far more than the preceding steps. The merge is performed by a `claude -p` sub-agent
+  doing a three-way semantic combine, so this step unblocks the entire deferred sub-agent subsystem:
+  `spawn_agent`, the shared async executor, `ClaudeCLIConfig`, and `MaintenanceConfig`, all of which
+  the minimal build defers together (see the `(deferred)` markers in `config.go` and the scope note
+  in `tools.go`). It also adds the merge mutex and its interaction with the memory mutex
+  ([Section 3.17](stateful-agent-design-chapter3.md#317-merge-process-and-merge-mutex)).
+- **Why last, and why it is a hard gate rather than a nicety:** branching without merging is
+  coherent but **monotonic** — every raced write forks a branch that nothing ever folds back, so
+  branch files accumulate without bound. Within a single bridge this accumulates slowly, but it does
+  accumulate. Merging is therefore not optional for a long-lived deployment; it is the second half of
+  branching. Its cost is that it cannot be done as a self-contained memory feature: it requires the
+  sub-agent machinery, which is why it is isolated as the final milestone rather than bundled with
+  step 6.
+
+### 13.5 Milestone Boundaries and Stopping Points
+
+There are exactly two safe places to stop, and one place that looks like a stopping point but is not:
+
+- **After step 6 — Branching milestone (safe, shippable).** Single-bridge branching is complete and
+  correct: concurrent conversations never silently overwrite one another. Deployable as-is for as
+  long as branch accumulation stays tolerable. This is the correct first delivery.
+- **After step 7 — Merging milestone (safe, complete for single-bridge).** Branches are folded back
+  on user-invoked maintenance; the single-bridge memory system matches the full Chapter 3
+  specification. This is the correct second delivery and the prerequisite for any multi-bridge /
+  Claude Code work ([Section 13.8](#138-relationship-to-multi-bridge-concurrency-section-325)).
+- **Between steps 6 and 7, as a permanent state — not safe.** Shipping branching with no merge path
+  and leaving it there indefinitely lets branches grow without bound. Acceptable as a temporary
+  milestone boundary; not acceptable as a destination.
+
+Steps 1–5 individually are **not** stopping points in the product sense — they add latent structure
+and corrective changes that are inert until step 6 switches branching on — but each is independently
+testable and should be landed and tested on its own before the next begins. In particular, steps 1,
+3, and 5 (the corrective ones) each warrant regression tests proving the pre-branching behavior is
+unchanged, since their whole risk is disturbing code that currently works.
+
+### 13.6 Dependency Summary
+
+```
+Step 1  content-hash signature   ─┐
+Step 2  branch map + persistence ─┤
+Step 3  branch-aware index+cache ─┼──►  Step 6  race-routing (BRANCHING)  ──►  Step 7  merge (MERGING)
+Step 4  branch filename codec    ─┤                                              │
+Step 5  atomic Windows replace   ─┘                                              └─ unblocks sub-agent
+                                                                                    subsystem (spawn_agent,
+   corrective: 1, 3, 5                                                              async executor, CLI cfg,
+   additive:   2, 4                                                                 maintenance cfg, merge mutex)
+```
+
+Steps 1–5 have no ordering dependencies *among themselves* and may be implemented in any internal
+order or in parallel; the numbering reflects recommended risk-first sequencing (corrective items and
+the hash the write decision depends on come first). Step 6 depends on all of 1–5. Step 7 depends on
+6.
+
+### 13.7 Effect on Chapter 7 (Build and Deployment)
+
+**Minimal to none.** Chapter 7 documents how to *build the binary and deploy it to clients* — compile
+the bridge, configure Claude Desktop and Claude Code, set up the memory directory, seed initial
+memory, install the skill. None of that is touched by *how the bridge's internals are ordered
+during implementation*. The appendix and Chapter 7 are orthogonal: Chapter 7 describes deploying
+whatever the current binary is, and this appendix describes the order in which that binary's features
+are written.
+
+There is exactly one forward coupling, and it is triggered by **step 7**, not by this appendix:
+
+- When the semantic-merge milestone lands, the sub-agent subsystem becomes live, which means the
+  bridge configuration grows the keys the minimal build marks `(deferred)` — the `claude -p` CLI path
+  (`ClaudeCLIConfig`), the async executor settings, and `MaintenanceConfig`. The configuration
+  example in [Section 7.2](stateful-agent-design-chapter7.md#72-claude-desktop-configuration) and the
+  build note in [Section 7.1](stateful-agent-design-chapter7.md#71-build-the-bridge) will need
+  **additive** updates at that point: new keys documented, nothing restructured or renumbered.
+
+That update is a consequence of *implementing merging*, not of *adding this appendix*, and it is
+purely additive. Steps 1–6 require **no** Chapter 7 change at all: branch files, the branch map,
+per-handle index caches, and the atomic replace are all internal to the bridge and invisible to
+deployment. So the answer to "will this cause much churn in Chapter 7" is: nothing now, and only a
+small additive config note whenever step 7 is eventually built.
+
+### 13.8 Relationship to Multi-Bridge Concurrency (Section 3.25)
+
+Two of the prerequisites here were originally specified in the multi-bridge section, and are pulled
+forward deliberately:
+
+- **The content-hash signature (step 1)** is specified in
+  [Section 3.25.5](stateful-agent-design-chapter3.md#3255-strengthening-the-read-baseline-signature)
+  as a multi-bridge hardening, but is a single-bridge *branching* prerequisite for the reason given in
+  step 1. Implementing it now is not premature multi-bridge work; it is required by single-bridge
+  branching and merely happens to also be needed later.
+- **The atomic Windows replace (step 5)** is likewise specified in
+  [Section 3.25.6](stateful-agent-design-chapter3.md#3256-atomic-replace-on-windows) but is a
+  single-bridge branching prerequisite (step 5's rationale).
+
+Implementing both in their Section 3.25 form now means they will not need to be revisited when
+multi-bridge support is built. **Everything else in Section 3.25 remains deferred** and must not be
+pulled forward: the cross-process file lock, per-client state files, client-scoped temp filenames,
+and the self-healing branch-map routing are multi-bridge concerns with no single-bridge purpose, and
+adding them now would be unused complexity. The correct reading is: single-bridge branching and
+merging (steps 1–7) come first and are a hard prerequisite for multi-bridge, because
+[Section 3.25.8](stateful-agent-design-chapter3.md#3258-effect-on-branching-and-merging) shows that
+multi-bridge turns branching from rare to routine — and there is no point making routine an operation
+that does not yet exist.

--- a/docs/stateful-agent-design/stateful-agent-design-chapter3.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter3.md
@@ -553,9 +553,10 @@ silently substituted.
 
 ```
 Name:        "memory_start_conversation"
-Description: "Start a memory conversation and receive a handle. Call this once
-             at the start of any conversation that will use memory, before any
-             other memory tool. Pass the returned handle to every subsequent
+Description: "Start a memory conversation and receive a handle, the current core
+             content, and the derived block index in one round trip. Call this
+             once at the start of any conversation that will use memory, before
+             any other memory tool. Pass the returned handle to every subsequent
              memory tool call. If any memory tool returns a handle error, call
              this again to obtain a fresh handle and retry the operation."
 
@@ -564,7 +565,23 @@ Input Schema:
 
 Output Schema:
   handle:  string   — Opaque 8-character handle (e.g., "h7k3xy90")
+  core:    string   — Current core content (empty string if the store is cold)
+  index:   Index    — The derived block index (empty array if no blocks exist)
 ```
+
+**Why the response bundles core and the index.** An earlier revision of this design returned the
+handle alone, leaving the skill to follow up with `memory_get_core` and `memory_get_index`. Those
+two calls are unconditional — every conversation that starts memory makes both, immediately — so
+the handle-only response guaranteed three round trips where one suffices. Bundling them removes two
+round trips at precisely the moment they are most costly: the start of a conversation, before the
+model has done anything useful for the user. It also removes two opportunities for the sequence to
+be abandoned partway through, which matters given the initialization-reliability concern recorded as
+OQ#18 ([Chapter 11](stateful-agent-design-chapter11.md#111-remaining-open-questions)).
+
+The baselines are recorded exactly as if the two calls had been made separately, so
+`changed_since_last_read` behaves identically on subsequent reads; bundling is a transport
+optimization, not a semantic change. `memory_get_core` and `memory_get_index` remain available and
+unchanged for re-reads later in the conversation.
 
 **Handler pseudo-code:**
 
@@ -589,7 +606,14 @@ func HandleMemoryStartConversation() MemoryStartConversationResult:
     //    the new handle survives a bridge restart.
     persistence.MarkDirty()
 
-    return { handle: handle }
+    // 5. Read core and derive the index under the new handle, recording this
+    //    handle's read baselines for both exactly as separate memory_get_core
+    //    and memory_get_index calls would have. A cold store is not an error:
+    //    core is returned as "" and the index as an empty array.
+    core  = readCore(handle)
+    index = deriveIndex(handle)
+
+    return { handle: handle, core: core, index: index }
 ```
 
 Note what this response deliberately does **not** include: a `branches_exist` flag, a pending-merge

--- a/docs/stateful-agent-design/stateful-agent-design-chapter5.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter5.md
@@ -70,9 +70,10 @@ to know how or where memory is stored.
 ## Handles
 
 Call `memory_start_conversation` once at the start of any conversation that will
-use memory. It returns a `handle` — an opaque token identifying this conversation.
-Pass the handle to every memory tool call, always using the most recently returned
-value (every memory tool response echoes it back).
+use memory. It returns a `handle` — an opaque token identifying this conversation —
+along with the current core content and the derived block index, all in one round
+trip. Pass the handle to every subsequent memory tool call, always using the most
+recently returned value (every memory tool response echoes it back).
 
 If any memory tool returns a handle error, the recovery is always the same:
 call `memory_start_conversation` to get a fresh handle, then retry the operation.
@@ -81,12 +82,11 @@ call `memory_start_conversation` to get a fresh handle, then retry the operation
 
 At the start of every conversation, BEFORE responding to the user's first message:
 
-1. Call `memory_start_conversation` to get a handle.
-2. Call `memory_get_core(handle)`.
-3. Call `memory_get_index(handle)`.
-4. If any index entry is relevant to the user's opening message, load it with
+1. Call `memory_start_conversation` to get a handle, the current core content,
+   and the derived index — all in one call.
+2. If any index entry is relevant to the user's opening message, load it with
    `memory_get_block(handle, block_name)`.
-5. Respond to the user, informed by your loaded context.
+3. Respond to the user, informed by your loaded context.
 
 If core comes back empty, this is a first-run scenario: write an initial core with
 `memory_write_core`, seeded from your built-in memory and the current conversation.
@@ -184,6 +184,16 @@ You can mention that the underlying storage is plain markdown files on their mac
 that they can edit directly — the bridge will pick up their edits.
 ```
 
+**This is the canonical full-design skill; a given build may ship a subset.** The `SKILL.md`
+deployed with a build must not instruct Claude to call tools that build does not register — an
+instruction to invoke a nonexistent tool is worse than a missing instruction, because the model
+will attempt it. Concretely, the minimal Layer 2 build in `fpl9000/mcp-bridge` registers eight
+tools and defers `memory_run_maintenance` along with the sub-agent machinery its semantic merge
+requires, so that build's `SKILL.md` correctly omits both the `## Memory Maintenance` section above
+and the `MAINTENANCE_IN_PROGRESS` bullet from `## Error Handling`. Those are restored when the tool
+is implemented, not before. When comparing a deployed `SKILL.md` against this section, check the
+build's registered tool list before treating a difference as drift.
+
 ### 5.3 Conversation Lifecycle
 
 Detailed sequence of operations at each phase:
@@ -193,12 +203,11 @@ Conversation Start
 │
 ├─ 1. Skill instructions loaded into context (automatic, ~400 tokens)
 ├─ 2. Layer 1 memory loaded into context (automatic, ~500–2,000 tokens)
-├─ 3. Call memory_start_conversation → receive handle (echoed on every later call)
-├─ 4. memory_get_core(handle) (~500–1,000 tokens)
-├─ 5. memory_get_index(handle) (~300–800 tokens)
-├─ 6. Evaluate user's first message against index entries
-├─ 7. memory_get_block(handle, name) for any relevant blocks (varies)
-└─ 8. Respond to user's first message
+├─ 3. Call memory_start_conversation → receive handle (echoed on every later
+│       call), core (~500–1,000 tokens), and the derived index (~300–800 tokens)
+├─ 4. Evaluate user's first message against index entries
+├─ 5. memory_get_block(handle, name) for any relevant blocks (varies)
+└─ 6. Respond to user's first message
 │
 Conversation Active
 │

--- a/docs/stateful-agent-design/stateful-agent-design.md
+++ b/docs/stateful-agent-design/stateful-agent-design.md
@@ -25,6 +25,7 @@
 - [10. References](#10-references)
 - [11. Open Questions](stateful-agent-design-chapter11.md)
 - [12. Appendix: mark3labs/mcp-go SDK Reference](stateful-agent-design-chapter12.md)
+- [13. Appendix: Implementation Ordering for Branching and Merging](stateful-agent-design-chapter13.md)
 
 ---
 
@@ -340,3 +341,7 @@ See [Stateful Agent System: Detailed Design – Chapter 11](stateful-agent-desig
 ## 12. Appendix: mark3labs/mcp-go SDK Reference
 
 See [Stateful Agent System: Detailed Design – Chapter 12](stateful-agent-design-chapter12.md).
+
+## 13. Appendix: Implementation Ordering for Branching and Merging
+
+See [Stateful Agent System: Detailed Design – Chapter 13](stateful-agent-design-chapter13.md). This appendix sequences the implementation of the branching and merging functionality that the minimal Layer 2 build omits, for the single-bridge case. It is a companion to the normative specification in [Chapter 3, Sections 3.15 and 3.17](stateful-agent-design-chapter3.md#315-per-handle-branching-and-race-detection).


### PR DESCRIPTION
Two changes that were pushed to the PR #51 branch **after** #51 had already been merged, and so never reached `main`. This PR re-lands them cleanly on top of the merged `main` (cherry-picked, no merge cruft). Both were reviewed and approved in the working session that produced #51.

## 1. Bundle core and index into `memory_start_conversation` (§§3.8, 5.2, 5.3)

Sections 3.8, 5.2, and 5.3 described a **handle-only** response from `memory_start_conversation`, with the skill following up with separate `memory_get_core` and `memory_get_index` calls. The shipped bridge instead returns `{ handle, core, index }` in one round trip, as specified in Section 3 of `mcp-bridge`'s `IMPLEMENTATION-PROMPT.md` and implemented in `handles.go`. Section 7.5 already assumed the bundled form, so the spec was internally consistent but collectively behind the implementation.

This **ratifies** the deviation rather than reverting it. Both follow-up calls are unconditional, so handle-only guaranteed three round trips where one suffices, and it created two extra points at which the startup sequence could be abandoned partway (cf. OQ#18, added in #51). Baselines are recorded as if the calls had been made separately, so `changed_since_last_read` is unaffected — it is a transport optimization with no semantic change. `memory_get_core` / `memory_get_index` remain available and unchanged for later re-reads.

§5.2 also gains a note that the canonical skill is the full design and a given build may ship a subset — a deployed `SKILL.md` must never instruct Claude to call a tool that build does not register (the current instance being the deferred `## Memory Maintenance` section and the `MAINTENANCE_IN_PROGRESS` bullet).

## 2. New Chapter 13 appendix: implementation ordering for branching & merging

A sequencing plan for adding the branching (§3.15) and semantic merge (§3.17) functionality that the minimal Layer 2 build omits, targeting the **single-bridge** case first. Placed as a new appendix chapter so no existing section is renumbered.

It enforces the no-re-implementation constraint (every step implements an existing Chapter 3 spec the minimal build explicitly deferred) and distinguishes **additive** steps (restore omitted structure) from **corrective** steps (code that is spec-compliant only because branches do not yet exist, and becomes spec-violating once they do), front-loading the corrective ones since their whole risk is disturbing code that currently works.

Ordered steps: (1) content-hash signature `[corrective]`, (2) restore `HandleState.Branches` + persistence, (3) branch-aware index and per-handle cache `[corrective]`, (4) branch filename codec, (5) atomic Windows replace `[corrective]`, (6) race-routing = branching proper, (7) semantic merge, which unblocks the deferred sub-agent subsystem. Two safe stopping points (after 6, after 7); branching-without-merging is flagged a valid temporary boundary but not a destination.

§13.7 records that **Chapter 7 needs no change** for steps 1–6, and only an additive config note when step 7 eventually lands (that update being triggered by implementing merge, not by this appendix). §13.8 pulls the content-hash signature (§3.25.5) and atomic replace (§3.25.6) forward from the multi-bridge phase with rationale for why each is a single-bridge branching prerequisite, and is explicit that nothing else from §3.25 should be pulled forward.

## Provenance note

The stranding happened because commits were pushed to the #51 branch after that PR was merged; a merged PR does not absorb later commits to its branch. Re-verified here: all internal cross-reference anchors resolve, and the §3.8/5.2/5.3 edits apply cleanly on top of the merged (pre-fix) `main`.