### PR TITLE
OQ#18 partial resolution: reject lazy handle minting; move bootstrap directive to unconditional channels

### DIFF
--- a/docs/stateful-agent-design/stateful-agent-design-chapter11.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter11.md
@@ -28,21 +28,37 @@ This section contains all questions that were ever open, even if they are now re
   search before they could be called; and a separate, non-deferred memory facility was available and
   was used instead.
 
-    - *Current status (open):* Unresolved, and **not** addressed by the `description` shortening of
-      [Chapter 5, Section 5.7](stateful-agent-design-chapter5.md#57-frontmatter-constraints-and-portability),
-      which governs only the field's length. Two directions are worth evaluating. (a) *Make
-      initialization unnecessary rather than mandatory:* have any memory tool lazily mint a handle
-      when called without a valid one, converting a client-side compliance requirement into a
-      bridge-side invariant that holds regardless of agent behavior. This would interact with the
-      no-graceful-re-init decision of
-      [Chapter 3, Section 3.14](stateful-agent-design-chapter3.md#314-handle-management), which
-      deliberately chose error-and-recover, so the tradeoff must be re-examined rather than assumed.
-      (b) *Move the directive to an unconditionally-loaded channel* — `CLAUDE.md` for Claude Code,
-      user preferences or project instructions for Claude Desktop — leaving the `description` to do
-      only what descriptions do reliably, which is trigger discovery. A prerequisite for evaluating
-      either is **measurement**: the bridge currently records nothing that would distinguish "no
-      memory was needed" from "initialization never happened," so the compliance rate is not
-      observable. Instrumenting that is the first step.
+    - *Current status (partially resolved; core reliability question still open):* Of the two
+      directions previously recorded, one is now decided against and one is adopted.
+
+        - *Direction (a) — lazy handle minting — REJECTED.* Having any memory tool mint a handle
+          when called without one would create a second handle-minting mechanism, and the
+          [Chapter 3, Section 3.3/3.14](stateful-agent-design-chapter3.md#314-handle-management)
+          decision that `memory_start_conversation` is the *sole* minting path and mandatory first
+          call is reaffirmed. Multiple minting mechanisms add bridge complexity, reintroduce the
+          handle-collision and honored-or-substituted reasoning burden that §3.3 was written to
+          avoid, and do so precisely at the one moment the agent must reliably bootstrap the memory
+          system and load `core.md` and the index. Simplicity at that moment is worth more than the
+          resilience lazy minting would buy, so the invariant is kept intact.
+
+        - *Direction (b) — move the directive to an unconditionally-loaded channel — ADOPTED.* The
+          bootstrap directive is now additionally carried in each client's always-loaded channel:
+          Claude Desktop user preferences and Claude Code `CLAUDE.md`, specified with proposed
+          wording in [Chapter 5, Section 5.8](stateful-agent-design-chapter5.md#58-bootstrapping-via-an-unconditionally-loaded-channel)
+          and [Chapter 6, Section 6.5](stateful-agent-design-chapter6.md#65-claudemd-recommendations)
+          respectively. The skill description and body are unchanged; execution reliability no longer
+          depends on the skill being judged relevant.
+
+        - *What remains open.* Whether direction (b) actually raises the bootstrap-compliance rate in
+          practice is an empirical question that is not yet answered. The instrument for answering it
+          already exists — the compliance-monitoring script of
+          [Chapter 8, Section 8.2.8](stateful-agent-design-chapter8.md#828-compliance-monitoring-script)
+          detects sessions that used memory tooling without a leading `memory_start_conversation` —
+          so the next step is to measure the rate before and after the channel change. (Note that the
+          richer "explicit vs. lazy initialization" denominator floated earlier is moot now that lazy
+          initialization is rejected: there is only one initialization path to count.) This question
+          stays in §11.1 until that measurement is in hand; if compliance remains inadequate even with
+          the unconditional-channel directive in place, the problem is escalated rather than closed.
 
 ### 11.2 Resolved Questions
 

--- a/docs/stateful-agent-design/stateful-agent-design-chapter5.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter5.md
@@ -15,6 +15,7 @@
   - [5.5 Memory Read Triggers](#55-memory-read-triggers)
   - [5.6 Reconciliation with Layer 1](#56-reconciliation-with-layer-1)
   - [5.7 Frontmatter Constraints and Portability](#57-frontmatter-constraints-and-portability)
+  - [5.8 Bootstrapping via an Unconditionally-Loaded Channel](#58-bootstrapping-via-an-unconditionally-loaded-channel)
 
 ## 5. Memory Skill
 
@@ -333,3 +334,55 @@ description neither causes nor cures this; the reliability of start-of-conversat
 is tracked separately as an open question
 ([Chapter 11](stateful-agent-design-chapter11.md#11-open-questions)) and is out of scope for this
 section, which governs only the field's length and content.
+
+### 5.8 Bootstrapping via an Unconditionally-Loaded Channel
+
+[Section 5.7](#57-frontmatter-constraints-and-portability) established that the skill `description`
+is metadata used to decide whether a skill is *relevant*, not a mechanism that guarantees an
+instruction is *executed* — and OQ#18
+([Chapter 11](stateful-agent-design-chapter11.md#111-remaining-open-questions)) records a real
+conversation in which the description was present in the skill listing and
+`memory_start_conversation` was nonetheless never called. Relying on the description alone to make
+the agent bootstrap memory is therefore unreliable by construction: the directive that governs the
+single most important action in the whole system — the mandatory first call that loads `core.md`
+and the block index — lives in a field whose job is discovery, and it is only elaborated in the
+skill body once the skill has already been judged relevant.
+
+**The resolution is to place the bootstrap directive additionally in a channel that is loaded
+verbatim into every conversation, with no relevance gating.** This does not replace the skill: the
+skill's conversation-start protocol ([Section 5.3](#53-conversation-lifecycle)) and its description
+remain exactly as specified, the description continuing to do the discovery job it does well. What
+changes is that *execution reliability no longer depends on relevance matching* — the unconditional
+channel carries the imperative, and the skill carries the detail. The two reinforce each other; the
+belt does not need the suspenders to be present, but both cost little and the failure mode being
+guarded against is silent.
+
+Each client has such a channel:
+
+- **Claude Desktop:** the user's preferences (Settings → Profile personalization), which are loaded
+  into every conversation. The wording below belongs there. (This is the same mechanism that already
+  reliably steers other cross-conversation behavior in this deployment, such as the GitHub and
+  Bluesky conventions.)
+- **Claude Code:** the auto-loaded `CLAUDE.md`. The wording, and an important sub-agent-safety
+  caveat, are given in [Section 6.5](stateful-agent-design-chapter6.md#65-claudemd-recommendations).
+
+**Proposed Claude Desktop user-preferences wording:**
+
+> At the start of every conversation, before doing anything else, call `memory_start_conversation`
+> to load my stored memory. It returns a handle together with my core memory and the block index;
+> use that handle on every subsequent memory tool call. If any memory tool reports an unknown or
+> invalid handle, call `memory_start_conversation` again to obtain a fresh handle and retry. This is
+> the only way to mint a handle — there is no other initialization path.
+
+The final sentence is deliberate: it reflects the reaffirmed decision
+([Chapter 3, Sections 3.3/3.14](stateful-agent-design-chapter3.md#314-handle-management)) that
+`memory_start_conversation` is the *sole* handle-minting mechanism and that the bridge performs no
+auto-initialization. Stating that plainly in the channel the agent actually reads removes any
+temptation to expect a handle to appear by some other means, and it makes the uniform error-recovery
+procedure ("get a new handle, retry") the obvious response to any handle error.
+
+**What this section does not do.** It does not weaken or bypass the mandatory-first-call invariant;
+it strengthens the odds that the invariant is honored by putting the instruction where it will be
+read every time. And it does not make initialization automatic — an agent that ignores both the
+unconditional channel and the skill still fails to bootstrap, and that residual case is exactly what
+OQ#18 leaves open pending measurement (see [Chapter 8, Section 8.2.8](stateful-agent-design-chapter8.md#828-compliance-monitoring-script)).

--- a/docs/stateful-agent-design/stateful-agent-design-chapter6.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter6.md
@@ -102,6 +102,9 @@ The file `C:\Users\flitt\.claude\CLAUDE.md` is loaded into every Claude Code inv
 - OS environment (Windows 11 + Cygwin, shell behavior, pathname conventions)
 - Available tools (compilers, package managers, utilities)
 - Source code conventions (line width, comments, encoding, newlines)
+- Memory bootstrap — the mandatory `memory_start_conversation` call at conversation start
+  (see the sub-agent-safety note below). This is session-core behavior, not a service-specific
+  instruction, so it is not excluded by the "should NOT include" rule that follows.
 
 **Should NOT include:**
 - Credentials (API tokens, passwords — use environment variables instead)
@@ -148,7 +151,34 @@ Recommended `CLAUDE.md` content:
 - Prefer Python and Bash for scripts. Use PEP 723 metadata in Python scripts.
 - Bash variables: UPPERCASE for globals, _UPPERCASE for function locals.
 - When building executables, always use .exe extension (Windows).
+
+# Memory Bootstrap
+
+- If the memory tools (memory_start_conversation and the other memory_* tools) are
+  available in this session, call memory_start_conversation ONCE, before any other
+  action, at the very start of the conversation. It returns a handle together with the
+  current core memory and the block index; pass that handle to every later memory tool
+  call. This is the only way to obtain a handle.
+- If a memory tool reports an unknown or invalid handle, call memory_start_conversation
+  again to get a fresh handle and retry.
+- If the memory tools are NOT available in this session, this instruction does not apply;
+  do nothing for it.
 ```
+
+**Sub-agent safety of the memory-bootstrap block.** The `CLAUDE.md` above is loaded into *every*
+Claude Code invocation, including sub-agents, and sub-agents do not inherit the parent session's MCP
+connections ([Section 7.8](stateful-agent-design-chapter7.md#78-claude-code-deployment)) — so a
+sub-agent has no memory tools. The block is therefore written as a **conditional guarded on tool
+availability**: the primary agent, which has the memory tools, acts on it; a sub-agent, which does
+not, treats it as inert. Without that guard the instruction would tell every sub-agent to call a
+tool it cannot reach, producing a guaranteed failed call at the top of every sub-agent run. The
+guard is the reason the directive is phrased "if the memory tools are available" rather than as a
+bare imperative. This is consistent with [Section 6.6](#66-sub-agent-memory-access-rules): sub-agents
+receive no Layer 2 write access, and here they correctly receive no bootstrap obligation either.
+
+The token cost of the block is small (well under 100 tokens), so it does not threaten the target
+size above. The rationale for placing it here at all — rather than relying on the skill description —
+is given in [Chapter 5, Section 5.8](stateful-agent-design-chapter5.md#58-bootstrapping-via-an-unconditionally-loaded-channel).
 
 ### 6.6 Sub-Agent Memory Access Rules
 


### PR DESCRIPTION
Codifies the **partial resolution of OQ#18** (reliability of start-of-conversation memory initialization) agreed in the working session. Documentation only — no code.

## The two directions, now decided

**Direction (a) — lazy handle minting — REJECTED.** Having any memory tool mint a handle when called without one would introduce a *second* handle-minting mechanism. The §3.3/§3.14 decision that `memory_start_conversation` is the **sole** minting path and the mandatory first call is reaffirmed. Multiple minting paths add bridge complexity and reintroduce exactly the handle-collision and "was my handle honored or substituted?" reasoning burden that §3.3 was written to eliminate — and they do so at the one moment the agent most needs to reliably bootstrap and load `core.md` and the index. Simplicity there outweighs the resilience lazy minting would buy.

**Direction (b) — move the directive to an unconditionally-loaded channel — ADOPTED.** The skill `description` is relevance-matching metadata, not an execution guarantee (§5.7), which is why the observed skip happened. The bootstrap directive is now additionally carried in each client's always-loaded channel:

- **New §5.8** states the principle and gives proposed **Claude Desktop user-preferences** wording.
- **§6.5** gains the **Claude Code `CLAUDE.md`** wording.

The skill description and body are unchanged; the description keeps doing discovery, and execution reliability no longer depends on the skill being judged relevant.

## The one non-obvious design point

The §6.5 `CLAUDE.md` wording is **guarded on tool availability**, not written as a bare imperative. `CLAUDE.md` is loaded into *every* Claude Code invocation including sub-agents, and sub-agents do not inherit the parent's MCP connections (§7.8) — so a sub-agent has no memory tools. A bare "call `memory_start_conversation` first" would therefore tell every sub-agent to call a tool it cannot reach, producing a guaranteed failed call at the top of every sub-agent run. The guard ("if the memory tools are available…") makes the block active for the primary agent and inert for sub-agents, consistent with §6.6's rule that sub-agents receive no Layer 2 obligations.

## What stays open

OQ#18 remains in §11.1, not moved to resolved, because whether (b) actually raises the compliance rate is **unmeasured**. The instrument already exists — the compliance-monitoring script of §8.2.8 flags sessions that used memory tooling without a leading `memory_start_conversation` — so the next step is to measure before/after. The richer "explicit vs. lazy" denominator discussed earlier is now moot: with lazy init rejected there is only one initialization path to count. If compliance stays inadequate with the directive in place, the question escalates rather than closing.

## Proposed wording (for review)

Both channels are written as **proposals** so you can adjust tone/length before adopting them into your live `CLAUDE.md` and Desktop preferences. The Desktop wording ends by stating plainly that `memory_start_conversation` is the only way to mint a handle, mirroring the uniform error-recovery procedure from §3.3.

## Verification

All internal cross-reference anchors resolve; §11.2 is not duplicated; the Chapter 5 TOC gains the §5.8 entry. Branched from current `main` (post-#52).