### PR TITLE
Spec: unwrap hard-wrapped paragraphs in the remaining chapters

### DIFF
--- a/docs/stateful-agent-design/stateful-agent-design-chapter3.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter3.md
@@ -37,12 +37,7 @@
 
 ## 3. MCP Bridge Server
 
-The MCP bridge server is a Go binary that runs locally, providing Bash access, sub-agent spawning,
-and memory access to be used by the Claude Desktop App via the MCP protocol. Memory access is
-provided through **memory-aware tools** that operate on memory concepts (core, blocks, the index)
-rather than on files — the bridge owns the entire file layout and the LLM never sees a file path,
-a branch, or any other storage detail. See [Section 3.7](#37-memory-aware-tools-overview-and-abstraction)
-for the abstraction model.
+The MCP bridge server is a Go binary that runs locally, providing Bash access, sub-agent spawning, and memory access to be used by the Claude Desktop App via the MCP protocol. Memory access is provided through **memory-aware tools** that operate on memory concepts (core, blocks, the index) rather than on files — the bridge owns the entire file layout and the LLM never sees a file path, a branch, or any other storage detail. See [Section 3.7](#37-memory-aware-tools-overview-and-abstraction) for the abstraction model.
 
 ### 3.1 Go Module Structure
 
@@ -164,10 +159,7 @@ claude_cli:
   path: "claude"                  # Or full path: "C:\\path\\to\\claude.exe"
 ```
 
-Note the absence of the old `session:` block: the `max_sessions` cap from the session-era design
-is gone (handle growth is bounded by the retention-based eviction policy in [Section 3.14](#314-handle-management),
-not by a hard cap — a hard cap is deferred to v1.x as a backstop), and the session ID length is
-replaced by `handle.id_length`.
+Note the absence of the old `session:` block: the `max_sessions` cap from the session-era design is gone (handle growth is bounded by the retention-based eviction policy in [Section 3.14](#314-handle-management), not by a hard cap — a hard cap is deferred to v1.x as a backstop), and the session ID length is replaced by `handle.id_length`.
 
 **Pseudo-code for configuration loading:**
 
@@ -208,8 +200,7 @@ The bridge registers twelve tools: three for sub-agents and local commands, and 
 | `memory_append_episodic`    | Append an entry to the current month's episodic log. The bridge handles month rotation internally.                                                                                                              |
 | `memory_run_maintenance`    | Merge pending memory branches back into canonical state via sub-agents, then sweep and evict stale handles. Invoked when the user asks for memory maintenance.                                                  |
 
-Every memory tool takes `handle` as its first, required parameter and echoes the handle back in
-every response (see [Section 3.7](#37-memory-aware-tools-overview-and-abstraction)).
+Every memory tool takes `handle` as its first, required parameter and echoes the handle back in every response (see [Section 3.7](#37-memory-aware-tools-overview-and-abstraction)).
 
 ### 3.4 Tool: spawn_agent
 
@@ -500,8 +491,7 @@ Middle truncation is preferred over tail truncation because command output often
 
 ### 3.7 Memory-Aware Tools: Overview and Abstraction
 
-The bridge's memory tools operate on **memory concepts, not files**. The LLM's mental model of
-the memory system consists of exactly five concepts:
+The bridge's memory tools operate on **memory concepts, not files**. The LLM's mental model of the memory system consists of exactly five concepts:
 
 | Concept | What the LLM knows about it |
 |---------|------------------------------|
@@ -511,43 +501,19 @@ the memory system consists of exactly five concepts:
 | **Summaries** | A one-line description attached to each block, supplied via the `summary` parameter of `memory_write_block`. |
 | **The index** | A structured roll-up of all blocks (`name`, `summary`, `updated_at`) returned by `memory_get_index`. The LLM calls a tool to get it; it does not read a file. |
 
-Everything else is bridge-internal and **invisible to the LLM**: file paths, the on-disk layout,
-YAML frontmatter, branches, the per-handle branch map, read baselines, the memory mutex, the merge
-mutex, and the state file. From the LLM's perspective, every read returns *the* current state of a
-target and every write succeeds — even when the bridge has transparently routed the operation
-through a per-handle branch file (see [Section 3.15](#315-per-handle-branching-and-race-detection)).
+Everything else is bridge-internal and **invisible to the LLM**: file paths, the on-disk layout, YAML frontmatter, branches, the per-handle branch map, read baselines, the memory mutex, the merge mutex, and the state file. From the LLM's perspective, every read returns *the* current state of a target and every write succeeds — even when the bridge has transparently routed the operation through a per-handle branch file (see [Section 3.15](#315-per-handle-branching-and-race-detection)).
 
-This is the central shift from the v1 design: **correctness no longer depends on LLM compliance.**
-The v1 design exposed file paths and branch content to the LLM and relied on skill instructions to
-keep the index in sync, use the right tools, and interpret branch annotations. The memory-aware
-design moves all of that into the bridge, where it is enforced by code. The skill (Chapter 5)
-shrinks accordingly: it now teaches *when* to read and write memory, not *how* the storage works.
+This is the central shift from the v1 design: **correctness no longer depends on LLM compliance.** The v1 design exposed file paths and branch content to the LLM and relied on skill instructions to keep the index in sync, use the right tools, and interpret branch annotations. The memory-aware design moves all of that into the bridge, where it is enforced by code. The skill (Chapter 5) shrinks accordingly: it now teaches *when* to read and write memory, not *how* the storage works.
 
-**The handle is echoed in every response.** Every memory tool response includes the `handle`
-field, not just the initial `memory_start_conversation` response. This refreshes the handle in the
-LLM's context on every memory tool call, dramatically reducing the chance that context compaction
-loses it. A conversation that has made any recent memory call will have its handle present in the
-surviving context.
+**The handle is echoed in every response.** Every memory tool response includes the `handle` field, not just the initial `memory_start_conversation` response. This refreshes the handle in the LLM's context on every memory tool call, dramatically reducing the chance that context compaction loses it. A conversation that has made any recent memory call will have its handle present in the surviving context.
 
-**Abstraction discipline.** Tool responses — including error responses — must never leak
-implementation details. An error message that mentions a branch filename, the merge mutex, or
-frontmatter teaches the LLM about machinery it must not reason about. The error response
-convention in [Section 3.19](#319-error-response-convention) enforces this.
+**Abstraction discipline.** Tool responses — including error responses — must never leak implementation details. An error message that mentions a branch filename, the merge mutex, or frontmatter teaches the LLM about machinery it must not reason about. The error response convention in [Section 3.19](#319-error-response-convention) enforces this.
 
 ### 3.8 Tool: memory_start_conversation
 
-This tool allocates a fresh handle for the calling conversation. The skill instructs Claude to call
-it once at the start of any conversation that will use memory, before any other memory tool, and to
-call it again as the uniform recovery step whenever any memory tool returns a handle error.
+This tool allocates a fresh handle for the calling conversation. The skill instructs Claude to call it once at the start of any conversation that will use memory, before any other memory tool, and to call it again as the uniform recovery step whenever any memory tool returns a handle error.
 
-**Why the bridge mints the handle (not the LLM):** If Claude composed its own identifier, it would
-need to reproduce it verbatim on every subsequent tool call — and LLMs are unreliable at exact
-string consistency across many calls. A bridge-minted short opaque handle is trivially
-reproducible: Claude just parrots back a fixed string, and that string reappears in every memory
-tool response to keep it fresh in context. Uniqueness is guaranteed by the bridge, which controls
-generation and checks for collisions. An LLM-supplied handle the bridge does not recognize is
-rejected with an error (see [Section 3.14](#314-handle-management)) — it is never honored or
-silently substituted.
+**Why the bridge mints the handle (not the LLM):** If Claude composed its own identifier, it would need to reproduce it verbatim on every subsequent tool call — and LLMs are unreliable at exact string consistency across many calls. A bridge-minted short opaque handle is trivially reproducible: Claude just parrots back a fixed string, and that string reappears in every memory tool response to keep it fresh in context. Uniqueness is guaranteed by the bridge, which controls generation and checks for collisions. An LLM-supplied handle the bridge does not recognize is rejected with an error (see [Section 3.14](#314-handle-management)) — it is never honored or silently substituted.
 
 **MCP tool definition:**
 
@@ -569,19 +535,9 @@ Output Schema:
   index:   Index    — The derived block index (empty array if no blocks exist)
 ```
 
-**Why the response bundles core and the index.** An earlier revision of this design returned the
-handle alone, leaving the skill to follow up with `memory_get_core` and `memory_get_index`. Those
-two calls are unconditional — every conversation that starts memory makes both, immediately — so
-the handle-only response guaranteed three round trips where one suffices. Bundling them removes two
-round trips at precisely the moment they are most costly: the start of a conversation, before the
-model has done anything useful for the user. It also removes two opportunities for the sequence to
-be abandoned partway through, which matters given the initialization-reliability concern recorded as
-OQ#18 ([Chapter 11](stateful-agent-design-chapter11.md#111-remaining-open-questions)).
+**Why the response bundles core and the index.** An earlier revision of this design returned the handle alone, leaving the skill to follow up with `memory_get_core` and `memory_get_index`. Those two calls are unconditional — every conversation that starts memory makes both, immediately — so the handle-only response guaranteed three round trips where one suffices. Bundling them removes two round trips at precisely the moment they are most costly: the start of a conversation, before the model has done anything useful for the user. It also removes two opportunities for the sequence to be abandoned partway through, which matters given the initialization-reliability concern recorded as OQ#18 ([Chapter 11](stateful-agent-design-chapter11.md#111-remaining-open-questions)).
 
-The baselines are recorded exactly as if the two calls had been made separately, so
-`changed_since_last_read` behaves identically on subsequent reads; bundling is a transport
-optimization, not a semantic change. `memory_get_core` and `memory_get_index` remain available and
-unchanged for re-reads later in the conversation.
+The baselines are recorded exactly as if the two calls had been made separately, so `changed_since_last_read` behaves identically on subsequent reads; bundling is a transport optimization, not a semantic change. `memory_get_core` and `memory_get_index` remain available and unchanged for re-reads later in the conversation.
 
 **Handler pseudo-code:**
 
@@ -616,18 +572,11 @@ func HandleMemoryStartConversation() MemoryStartConversationResult:
     return { handle: handle, core: core, index: index }
 ```
 
-Note what this response deliberately does **not** include: a `branches_exist` flag, a pending-merge
-count, or any other branch surfacing. Branches are invisible to the LLM
-(see [Section 3.15](#315-per-handle-branching-and-race-detection)), and pending-merge debris from
-abandoned conversations is reaped by `memory_run_maintenance` on the user's schedule — there is
-nothing the LLM needs to be told at conversation start.
+Note what this response deliberately does **not** include: a `branches_exist` flag, a pending-merge count, or any other branch surfacing. Branches are invisible to the LLM (see [Section 3.15](#315-per-handle-branching-and-race-detection)), and pending-merge debris from abandoned conversations is reaped by `memory_run_maintenance` on the user's schedule — there is nothing the LLM needs to be told at conversation start.
 
 ### 3.9 Tools: memory_get_core and memory_write_core
 
-Core memory is a single always-loaded prose document — the Layer 2 equivalent of "who am I and
-what are we working on" (see [Chapter 4, Section 4.3](stateful-agent-design-chapter4.md#43-file-format-coremd)).
-These two tools read and replace it. The bridge maps "core" to its on-disk location
-(`<memory.directory>\core.md`); the LLM never sees that path.
+Core memory is a single always-loaded prose document — the Layer 2 equivalent of "who am I and what are we working on" (see [Chapter 4, Section 4.3](stateful-agent-design-chapter4.md#43-file-format-coremd)). These two tools read and replace it. The bridge maps "core" to its on-disk location (`<memory.directory>\core.md`); the LLM never sees that path.
 
 **MCP tool definitions:**
 
@@ -704,43 +653,17 @@ func HandleMemoryGet(handle string, target Target) MemoryGetResult:
     return { handle: handle, content: content, changed_since_last_read: changed }
 ```
 
-**Write handler:** `memory_write_core` follows the shared write path described in
-[Section 3.15](#315-per-handle-branching-and-race-detection): if this handle already owns a branch
-of core, the write goes to that branch; otherwise the base signature is compared against this
-handle's read baseline, and the write goes to the base (signatures match) or to a newly created
-branch (signatures differ). The write itself is atomic per [Section 3.16](#316-block-file-format-and-atomic-writes).
-In every case the tool returns `{ handle, ok: true }` — the LLM is never told which file received
-the write.
+**Write handler:** `memory_write_core` follows the shared write path described in [Section 3.15](#315-per-handle-branching-and-race-detection): if this handle already owns a branch of core, the write goes to that branch; otherwise the base signature is compared against this handle's read baseline, and the write goes to the base (signatures match) or to a newly created branch (signatures differ). The write itself is atomic per [Section 3.16](#316-block-file-format-and-atomic-writes). In every case the tool returns `{ handle, ok: true }` — the LLM is never told which file received the write.
 
-**The `changed_since_last_read` flag** is the v1 mitigation for the cross-conversation visibility
-of writes. v1 ships with branch-on-race-only semantics (not snapshot isolation), so when another
-conversation legitimately writes core or a block (no race), this conversation's next read returns
-the new content. The flag tells the LLM "your prior view is stale" without revealing *what*
-changed or *who* changed it — preserving per-conversation isolation (conversation X cannot
-introspect conversation Y's activity) while letting X know to re-derive anything that depended on
-the earlier content. The stricter snapshot-isolation alternative (branching on every
-write-while-others-have-outstanding-reads) was considered and deferred to v1.x: it would make
-almost every write to a hot target branch, exploding the merge load, to prevent a surprise that is
-hypothetical until observed in practice. (Decision record: update plan §3.2.)
+**The `changed_since_last_read` flag** is the v1 mitigation for the cross-conversation visibility of writes. v1 ships with branch-on-race-only semantics (not snapshot isolation), so when another conversation legitimately writes core or a block (no race), this conversation's next read returns the new content. The flag tells the LLM "your prior view is stale" without revealing *what* changed or *who* changed it — preserving per-conversation isolation (conversation X cannot introspect conversation Y's activity) while letting X know to re-derive anything that depended on the earlier content. The stricter snapshot-isolation alternative (branching on every write-while-others-have-outstanding-reads) was considered and deferred to v1.x: it would make almost every write to a hot target branch, exploding the merge load, to prevent a surprise that is hypothetical until observed in practice. (Decision record: update plan §3.2.)
 
-`memory_get_index` does not carry a `changed_since_last_read` flag in v1 — per-block changes are
-already signaled by the per-block read flag. It can be added later if it proves useful.
+`memory_get_index` does not carry a `changed_since_last_read` flag in v1 — per-block changes are already signaled by the per-block read flag. It can be added later if it proves useful.
 
 ### 3.10 Tool: memory_get_index
 
-The index is a **derived view, not a stored file**. There is no `index.md` on disk. Each block's
-`summary` and `updated_at` live in YAML frontmatter inside the block file itself
-(see [Section 3.16](#316-block-file-format-and-atomic-writes)), and `memory_get_index` assembles
-the index on demand by walking the blocks directory.
+The index is a **derived view, not a stored file**. There is no `index.md` on disk. Each block's `summary` and `updated_at` live in YAML frontmatter inside the block file itself (see [Section 3.16](#316-block-file-format-and-atomic-writes)), and `memory_get_index` assembles the index on demand by walking the blocks directory.
 
-**Why derived:** A stored index file would have to be updated on every block write, and under the
-per-handle branch model that creates a leakage problem: conversation Y's summary updates would
-land in a canonical index file and become visible to conversation X, even while Y's block content
-was correctly isolated in a branch. (The original stored-index design had exactly this flaw —
-decision record: update plan §2.8.) Deriving the index from the same files the per-block reads use
-makes the leak impossible by construction: handle H's index view is assembled from H's branches
-plus the bases of blocks H hasn't branched — exactly what H's per-block reads return. The index
-and the blocks are guaranteed consistent because they come from the same files.
+**Why derived:** A stored index file would have to be updated on every block write, and under the per-handle branch model that creates a leakage problem: conversation Y's summary updates would land in a canonical index file and become visible to conversation X, even while Y's block content was correctly isolated in a branch. (The original stored-index design had exactly this flaw — decision record: update plan §2.8.) Deriving the index from the same files the per-block reads use makes the leak impossible by construction: handle H's index view is assembled from H's branches plus the bases of blocks H hasn't branched — exactly what H's per-block reads return. The index and the blocks are guaranteed consistent because they come from the same files.
 
 **MCP tool definition:**
 
@@ -776,14 +699,8 @@ Output Schema:
 
 Notes on the schema:
 
-- **Ordering:** stable sort by `name`. Insertion order would be subtle to maintain across bridge
-  restarts, and `updated_at` order would change on every write, which is disruptive for the LLM's
-  mental model of the index.
-- **Timestamp format:** `updated_at` uses *extended* ISO 8601 (`2026-05-20T14:23:00Z`). This
-  intentionally differs from the *compact* form used in branch filenames
-  ([Section 3.15](#315-per-handle-branching-and-race-detection)): colons are legal in JSON string
-  values, so the more readable extended form is used there; the compact form is only required
-  where Windows filename rules forbid colons. The two formats coexisting is deliberate.
+- **Ordering:** stable sort by `name`. Insertion order would be subtle to maintain across bridge restarts, and `updated_at` order would change on every write, which is disruptive for the LLM's mental model of the index.
+- **Timestamp format:** `updated_at` uses *extended* ISO 8601 (`2026-05-20T14:23:00Z`). This intentionally differs from the *compact* form used in branch filenames ([Section 3.15](#315-per-handle-branching-and-race-detection)): colons are legal in JSON string values, so the more readable extended form is used there; the compact form is only required where Windows filename rules forbid colons. The two formats coexisting is deliberate.
 - **Pagination:** none in v1. If the index grows past ~500 entries, revisit.
 
 **Assembly pseudo-code:**
@@ -805,24 +722,13 @@ func HandleMemoryGetIndex(handle string) MemoryGetIndexResult:
     // 5. Sort entries by name and return the assembled index.
 ```
 
-**Caching:** `memory_get_index` is O(n_blocks) in the worst case. The bridge maintains an
-in-memory cache of assembled index views: one per handle, invalidated when that handle writes a
-block or when the blocks directory's most recent mtime changes. Steady-state cost is a cached
-lookup; the walk runs only when the cache is stale.
+**Caching:** `memory_get_index` is O(n_blocks) in the worst case. The bridge maintains an in-memory cache of assembled index views: one per handle, invalidated when that handle writes a block or when the blocks directory's most recent mtime changes. Steady-state cost is a cached lookup; the walk runs only when the cache is stale.
 
-**Debugging:** A human can inspect block metadata by opening any block file — the frontmatter is
-at the top. If a human-readable index snapshot is ever wanted, a `memory_dump_index(handle, path)`
-tool that writes the current derived view to a user-named file *outside* the memory directory can
-be added later; it is not part of v1.
+**Debugging:** A human can inspect block metadata by opening any block file — the frontmatter is at the top. If a human-readable index snapshot is ever wanted, a `memory_dump_index(handle, path)` tool that writes the current derived view to a user-named file *outside* the memory directory can be added later; it is not part of v1.
 
 ### 3.11 Tools: memory_get_block, memory_write_block, memory_append_block
 
-Blocks are the named content documents of Layer 2 memory (`project-foo`, `decisions`,
-`episodic-2026-06`, ...). The LLM addresses them by **name only** — the bridge maps a block name
-to its on-disk file (`<memory.directory>\blocks\<name>.md`) and manages the YAML frontmatter
-transparently. Block names may contain letters, digits, hyphens, and underscores; anything else is
-rejected with `INVALID_BLOCK_NAME`. Naming conventions (which prefixes mean what) are documented
-in [Chapter 4, Section 4.8](stateful-agent-design-chapter4.md#48-block-naming-conventions).
+Blocks are the named content documents of Layer 2 memory (`project-foo`, `decisions`, `episodic-2026-06`, ...). The LLM addresses them by **name only** — the bridge maps a block name to its on-disk file (`<memory.directory>\blocks\<name>.md`) and manages the YAML frontmatter transparently. Block names may contain letters, digits, hyphens, and underscores; anything else is rejected with `INVALID_BLOCK_NAME`. Naming conventions (which prefixes mean what) are documented in [Chapter 4, Section 4.8](stateful-agent-design-chapter4.md#48-block-naming-conventions).
 
 **MCP tool definitions:**
 
@@ -881,55 +787,24 @@ Output Schema:
 
 **The `summary` parameter contract** (decision record: update plan §3.5):
 
-- **For new blocks** (no block file with that name visible to this handle): `summary` is
-  **required**. The bridge rejects the call with `SUMMARY_REQUIRED` if it is absent. A block must
-  enter the index with a meaningful description.
-- **For existing blocks:** `summary` is optional. If absent, the existing summary in the block's
-  frontmatter is preserved unchanged. If present (including the empty string), it replaces the
-  existing summary.
-- **Length:** capped at `memory.summary_max_length` (default 200 characters). Longer summaries are
-  truncated and the response includes a warning; alternatively the bridge may reject with
-  `SUMMARY_TOO_LONG` if truncation would be misleading.
+- **For new blocks** (no block file with that name visible to this handle): `summary` is **required**. The bridge rejects the call with `SUMMARY_REQUIRED` if it is absent. A block must enter the index with a meaningful description.
+- **For existing blocks:** `summary` is optional. If absent, the existing summary in the block's frontmatter is preserved unchanged. If present (including the empty string), it replaces the existing summary.
+- **Length:** capped at `memory.summary_max_length` (default 200 characters). Longer summaries are truncated and the response includes a warning; alternatively the bridge may reject with `SUMMARY_TOO_LONG` if truncation would be misleading.
 
-There is **no separate index-update tool** and no index-update instruction in the skill. The
-summary travels with the block content in a single `memory_write_block` call, and the bridge
-writes frontmatter and body together as one file ([Section 3.16](#316-block-file-format-and-atomic-writes)),
-so the index can never drift out of sync with the blocks — a whole category of v1 compliance
-failures is eliminated structurally.
+There is **no separate index-update tool** and no index-update instruction in the skill. The summary travels with the block content in a single `memory_write_block` call, and the bridge writes frontmatter and body together as one file ([Section 3.16](#316-block-file-format-and-atomic-writes)), so the index can never drift out of sync with the blocks — a whole category of v1 compliance failures is eliminated structurally.
 
-**Read behavior:** `memory_get_block` follows the shared read path in
-[Section 3.9](#39-tools-memory_get_core-and-memory_write_core): branch-or-base file selection,
-frontmatter stripped, baseline recorded, `changed_since_last_read` computed. Reading a block that
-does not exist (no base file and no branch for this handle) returns `BLOCK_NOT_FOUND`.
+**Read behavior:** `memory_get_block` follows the shared read path in [Section 3.9](#39-tools-memory_get_core-and-memory_write_core): branch-or-base file selection, frontmatter stripped, baseline recorded, `changed_since_last_read` computed. Reading a block that does not exist (no base file and no branch for this handle) returns `BLOCK_NOT_FOUND`.
 
-**Write behavior:** `memory_write_block` follows the shared race-detected write path in
-[Section 3.15](#315-per-handle-branching-and-race-detection). Writing a block that does not exist
-creates the base file (a true first creation has no race to detect — but see Section 3.15 for the
-simultaneous-first-write case, which does branch).
+**Write behavior:** `memory_write_block` follows the shared race-detected write path in [Section 3.15](#315-per-handle-branching-and-race-detection). Writing a block that does not exist creates the base file (a true first creation has no race to detect — but see Section 3.15 for the simultaneous-first-write case, which does branch).
 
-**Append semantics — serialized, never branched** (decision record: update plan §2.11): appends
-are serialized by the memory mutex and **never create a branch**. The semantic justification:
-appends are commutative when the order isn't load-bearing, and for episodic logs (the primary
-append use case) chronological ordering is already approximate. Race detection on appends would
-produce branches that need semantic merging for no real benefit; serializing avoids the problem
-entirely. Two routing details preserve consistency:
+**Append semantics — serialized, never branched** (decision record: update plan §2.11): appends are serialized by the memory mutex and **never create a branch**. The semantic justification: appends are commutative when the order isn't load-bearing, and for episodic logs (the primary append use case) chronological ordering is already approximate. Race detection on appends would produce branches that need semantic merging for no real benefit; serializing avoids the problem entirely. Two routing details preserve consistency:
 
-- If this handle already owns a branch of the target block (from a prior racing *write*), the
-  append goes to **that branch** — otherwise the handle's next read (which routes through its
-  branch) would not show the appended text, violating read-your-own-writes.
-- Otherwise the append goes to the base file, regardless of baselines. The handle's read baseline
-  for the block is updated to the post-append signature so the append doesn't trigger a spurious
-  race on this handle's next full write.
+- If this handle already owns a branch of the target block (from a prior racing *write*), the append goes to **that branch** — otherwise the handle's next read (which routes through its branch) would not show the appended text, violating read-your-own-writes.
+- Otherwise the append goes to the base file, regardless of baselines. The handle's read baseline for the block is updated to the post-append signature so the append doesn't trigger a spurious race on this handle's next full write.
 
 ### 3.12 Tool: memory_append_episodic
 
-Episodic logs are a distinct file category from ordinary blocks: monthly files
-(`episodic-YYYY-MM.md`) holding dated entries for significant conversations
-(see [Chapter 4, Section 4.6](stateful-agent-design-chapter4.md#46-file-format-episodic-logs)).
-This tool appends an entry to the **current month's** log; the bridge selects the target file
-from the system clock and creates a new month's file automatically at each rollover. The LLM
-never computes a filename or even a block name to append an episodic entry — this matches the
-"bridge owns the file layout" principle.
+Episodic logs are a distinct file category from ordinary blocks: monthly files (`episodic-YYYY-MM.md`) holding dated entries for significant conversations (see [Chapter 4, Section 4.6](stateful-agent-design-chapter4.md#46-file-format-episodic-logs)). This tool appends an entry to the **current month's** log; the bridge selects the target file from the system clock and creates a new month's file automatically at each rollover. The LLM never computes a filename or even a block name to append an episodic entry — this matches the "bridge owns the file layout" principle.
 
 **MCP tool definition:**
 
@@ -951,28 +826,12 @@ Output Schema:
 
 **Behavior details:**
 
-- Month rotation is internal: the bridge computes `episodic-YYYY-MM` from the current local date.
-  On the first append of a new month, the bridge creates the file with bridge-generated
-  frontmatter (`summary: "Conversation log for <Month YYYY>"`, `updated_at` set to now) and a
-  `# <Month YYYY>` heading, then appends the entry.
-- Episodic files live in the blocks directory and carry frontmatter like any other block, so they
-  **appear in the derived index** and are readable via `memory_get_block` (using the name shown in
-  the index, e.g., `episodic-2026-06`). `memory_append_episodic` is a convenience over
-  `memory_append_block` that removes the burden of computing the current month's name; it shares
-  the same append semantics (serialized, never branched, branch-routed if one exists) from
-  [Section 3.11](#311-tools-memory_get_block-memory_write_block-memory_append_block). Each append
-  also refreshes the file's `updated_at` frontmatter so the index reflects the last entry time.
+- Month rotation is internal: the bridge computes `episodic-YYYY-MM` from the current local date. On the first append of a new month, the bridge creates the file with bridge-generated frontmatter (`summary: "Conversation log for <Month YYYY>"`, `updated_at` set to now) and a `# <Month YYYY>` heading, then appends the entry.
+- Episodic files live in the blocks directory and carry frontmatter like any other block, so they **appear in the derived index** and are readable via `memory_get_block` (using the name shown in the index, e.g., `episodic-2026-06`). `memory_append_episodic` is a convenience over `memory_append_block` that removes the burden of computing the current month's name; it shares the same append semantics (serialized, never branched, branch-routed if one exists) from [Section 3.11](#311-tools-memory_get_block-memory_write_block-memory_append_block). Each append also refreshes the file's `updated_at` frontmatter so the index reflects the last entry time.
 
 ### 3.13 Tool: memory_run_maintenance
 
-Maintenance is the manually triggered process that folds pending memory branches back into
-canonical state and reaps stale handle records. v1 has **no automatic merge scheduling**: merges
-happen when, and only when, the user asks for them (in any phrasing — "run memory maintenance,"
-"merge memory," "consolidate your memory," etc.), which causes the LLM to call this tool. The
-manual approach is correct (merges happen when asked) and operable (the user controls timing); it
-sidesteps the unattended-execution problem entirely. Automated triggers (Task Scheduler +
-`claude -p`, AutoHotkey, lazy merge at conversation start) are deferred to v1.x. (Decision record:
-update plan §3.1, §3.9.)
+Maintenance is the manually triggered process that folds pending memory branches back into canonical state and reaps stale handle records. v1 has **no automatic merge scheduling**: merges happen when, and only when, the user asks for them (in any phrasing — "run memory maintenance," "merge memory," "consolidate your memory," etc.), which causes the LLM to call this tool. The manual approach is correct (merges happen when asked) and operable (the user controls timing); it sidesteps the unattended-execution problem entirely. Automated triggers (Task Scheduler + `claude -p`, AutoHotkey, lazy merge at conversation start) are deferred to v1.x. (Decision record: update plan §3.1, §3.9.)
 
 **MCP tool definition:**
 
@@ -1003,60 +862,26 @@ Output Schema:
 **Handler behavior:**
 
 1. Validate the handle and acquire no long-lived locks yet.
-2. **Enumerate pending work:** scan the memory directory for *all* branch files on disk —
-   regardless of whether their owning handles are live. Branches from abandoned conversations are
-   merged exactly like branches from active ones; from the merge's perspective, branched content
-   is branched content. Group branch files by their base block.
+2. **Enumerate pending work:** scan the memory directory for *all* branch files on disk — regardless of whether their owning handles are live. Branches from abandoned conversations are merged exactly like branches from active ones; from the merge's perspective, branched content is branched content. Group branch files by their base block.
 3. **Apply the per-call cap:** process at most `maintenance.max_blocks_per_call` blocks (default
-   10) in this invocation. This keeps the synchronous call comfortably under the MCP tool-call
-   timeout even when many branches have accumulated (each block's semantic merge costs a sub-agent
-   invocation, ~30s). If blocks remain after the cap, return `more_pending: true` and let the LLM
-   call again. (Alternatives considered and rejected for v1: routing maintenance through the async
-   job infrastructure of [Section 3.20](#320-async-executor) — adds polling complexity; fully
-   synchronous with no cap — risks timeouts on large batches. Decision record: update plan §3.1.)
-4. **For each selected block,** run the merge process of
-   [Section 3.17](#317-merge-process-and-merge-mutex): acquire the merge mutex, semantically merge
-   the base and all its branches via an LLM sub-agent, atomically replace the base, delete the
-   branch files, clear all branch-map entries for the block, release the mutex. A per-block
-   failure (sub-agent error, malformed output) leaves that block's base and branches untouched,
-   records an entry in `errors`, and continues with the next block.
-5. **Handle cleanup sweep** ([Section 3.14](#314-handle-management)): after the merge pass, evict
-   every handle that owns zero branches and has been inactive past the retention window. Also drop
-   read baselines that reference blocks which no longer exist.
+   10) in this invocation. This keeps the synchronous call comfortably under the MCP tool-call timeout even when many branches have accumulated (each block's semantic merge costs a sub-agent invocation, ~30s). If blocks remain after the cap, return `more_pending: true` and let the LLM call again. (Alternatives considered and rejected for v1: routing maintenance through the async job infrastructure of [Section 3.20](#320-async-executor) — adds polling complexity; fully synchronous with no cap — risks timeouts on large batches. Decision record: update plan §3.1.)
+4. **For each selected block,** run the merge process of [Section 3.17](#317-merge-process-and-merge-mutex): acquire the merge mutex, semantically merge the base and all its branches via an LLM sub-agent, atomically replace the base, delete the branch files, clear all branch-map entries for the block, release the mutex. A per-block failure (sub-agent error, malformed output) leaves that block's base and branches untouched, records an entry in `errors`, and continues with the next block.
+5. **Handle cleanup sweep** ([Section 3.14](#314-handle-management)): after the merge pass, evict every handle that owns zero branches and has been inactive past the retention window. Also drop read baselines that reference blocks which no longer exist.
 6. Write a persistence checkpoint and return.
 
-**Behavior with no pending branches:** returns `{ ok: true, merged_blocks: 0, more_pending: false }`
-immediately (the cleanup sweep still runs — it is cheap).
+**Behavior with no pending branches:** returns `{ ok: true, merged_blocks: 0, more_pending: false }` immediately (the cleanup sweep still runs — it is cheap).
 
-**Partial / targeted maintenance** (merging a single named block) is not supported in v1; the call
-always processes everything pending, up to the cap. A `block_name` parameter is a v1.x option if it
-proves useful.
+**Partial / targeted maintenance** (merging a single named block) is not supported in v1; the call always processes everything pending, up to the cap. A `block_name` parameter is a v1.x option if it proves useful.
 
-**Concurrency:** if the user triggers maintenance while other conversations are active, those
-conversations' memory tool calls block on the merge mutex for the duration of each block's merge.
-This is acceptable for v1 — the user chooses when to run maintenance and can pick an idle moment.
-The skill mentions the brief blocking so the LLM can set expectations
-([Chapter 5](stateful-agent-design-chapter5.md)). If blocking on the mutex would exceed an
-acceptable wait, the bridge returns `MAINTENANCE_IN_PROGRESS` to the blocked caller rather than
-hanging the tool call indefinitely; the message instructs the LLM to retry shortly.
+**Concurrency:** if the user triggers maintenance while other conversations are active, those conversations' memory tool calls block on the merge mutex for the duration of each block's merge. This is acceptable for v1 — the user chooses when to run maintenance and can pick an idle moment. The skill mentions the brief blocking so the LLM can set expectations ([Chapter 5](stateful-agent-design-chapter5.md)). If blocking on the mutex would exceed an acceptable wait, the bridge returns `MAINTENANCE_IN_PROGRESS` to the blocked caller rather than hanging the tool call indefinitely; the message instructs the LLM to retry shortly.
 
 ### 3.14 Handle Management
 
-The handle is the bridge's identifier for a conversation. It replaces the v1 session ID, and the
-per-handle state replaces the v1 session tracker.
+The handle is the bridge's identifier for a conversation. It replaces the v1 session ID, and the per-handle state replaces the v1 session tracker.
 
-**Format.** Handles are **8 lowercase alphanumeric characters** (alphabet `[a-z0-9]`, ~2.8 × 10¹²
-possibilities), e.g., `h7k3xy90`. The length costs a few tokens per response (the handle is echoed
-in every memory tool response) and makes collisions astronomically unlikely even across bridge
-restarts and long-lived conversations.
+**Format.** Handles are **8 lowercase alphanumeric characters** (alphabet `[a-z0-9]`, ~2.8 × 10¹² possibilities), e.g., `h7k3xy90`. The length costs a few tokens per response (the handle is echoed in every memory tool response) and makes collisions astronomically unlikely even across bridge restarts and long-lived conversations.
 
-**Generation.** The bridge mints handles; the LLM never invents one. v1 uses a standard PRNG
-(`math/rand`, seeded at bridge startup) plus the collision check in
-[Section 3.8](#38-tool-memory_start_conversation). The probability of meaningful collisions with
-PRNG output at this handle length is negligible for the expected workload, and an unprivileged LLM
-has no way to predict or attack handle values through the MCP interface. **Future improvement:**
-upgrade to a CSPRNG (`crypto/rand`) if the threat model grows to include adversarial scenarios —
-e.g., if memory ever becomes accessible to untrusted parties. Noted here so it isn't forgotten.
+**Generation.** The bridge mints handles; the LLM never invents one. v1 uses a standard PRNG (`math/rand`, seeded at bridge startup) plus the collision check in [Section 3.8](#38-tool-memory_start_conversation). The probability of meaningful collisions with PRNG output at this handle length is negligible for the expected workload, and an unprivileged LLM has no way to predict or attack handle values through the MCP interface. **Future improvement:** upgrade to a CSPRNG (`crypto/rand`) if the threat model grows to include adversarial scenarios — e.g., if memory ever becomes accessible to untrusted parties. Noted here so it isn't forgotten.
 
 **Per-handle state.** For each live handle the bridge tracks:
 
@@ -1074,32 +899,15 @@ type HandleMap struct {
 }
 ```
 
-This state is persisted across bridge restarts in `.bridge-state.json`
-([Section 3.18](#318-bridge-state-persistence-and-recovery)), so a handle issued in one Claude
-Desktop session is still valid — with its full branch map and read baselines — after the app is
-closed and reopened.
+This state is persisted across bridge restarts in `.bridge-state.json` ([Section 3.18](#318-bridge-state-persistence-and-recovery)), so a handle issued in one Claude Desktop session is still valid — with its full branch map and read baselines — after the app is closed and reopened.
 
-**Handle is a required parameter with no graceful re-init.** Every memory tool declares `handle`
-as required in its MCP schema, so an omitted handle is rejected by schema validation before the
-call reaches the bridge. The bridge itself rejects malformed and unrecognized handles with errors;
-it never silently registers an unknown handle. The error-and-recover model keeps the bridge simple
-and the semantics predictable: the SKILL teaches one uniform recovery for *any* handle problem —
-**call `memory_start_conversation` to obtain a fresh handle and retry**. (Decision record: update
-plan §3.3.)
+**Handle is a required parameter with no graceful re-init.** Every memory tool declares `handle` as required in its MCP schema, so an omitted handle is rejected by schema validation before the call reaches the bridge. The bridge itself rejects malformed and unrecognized handles with errors; it never silently registers an unknown handle. The error-and-recover model keeps the bridge simple and the semantics predictable: the SKILL teaches one uniform recovery for *any* handle problem — **call `memory_start_conversation` to obtain a fresh handle and retry**. (Decision record: update plan §3.3.)
 
-**The unknown-handle procedure.** With persistence in place, a handle from a prior Claude Desktop
-session is normally already in the map after the startup load — the path below is the exception,
-not the rule:
+**The unknown-handle procedure.** With persistence in place, a handle from a prior Claude Desktop session is normally already in the map after the startup load — the path below is the exception, not the rule:
 
-1. If the handle is malformed (wrong length or character set), return `MALFORMED_HANDLE`
-   immediately — no adoption attempt.
-2. If the handle is well-formed but not in the in-memory map, scan the memory directory for branch
-   files matching `*.branch-<handle>-*.<ext>` (**lazy adoption**, the reconciliation backstop —
-   see [Section 3.18](#318-bridge-state-persistence-and-recovery)).
-3. If any branch files match, reconstruct the corresponding `(handle, block) → branch path`
-   entries, treat the handle as live, and proceed with the original tool call. Read baselines
-   cannot be reconstructed from disk, so the handle's first read of each target sets a fresh
-   baseline with `changed_since_last_read: false` (same as a brand-new handle).
+1. If the handle is malformed (wrong length or character set), return `MALFORMED_HANDLE` immediately — no adoption attempt.
+2. If the handle is well-formed but not in the in-memory map, scan the memory directory for branch files matching `*.branch-<handle>-*.<ext>` (**lazy adoption**, the reconciliation backstop — see [Section 3.18](#318-bridge-state-persistence-and-recovery)).
+3. If any branch files match, reconstruct the corresponding `(handle, block) → branch path` entries, treat the handle as live, and proceed with the original tool call. Read baselines cannot be reconstructed from disk, so the handle's first read of each target sets a fresh baseline with `changed_since_last_read: false` (same as a brand-new handle).
 4. If no branch files match, return `INVALID_HANDLE`.
 
 **Failure modes and recovery:**
@@ -1116,49 +924,22 @@ not the rule:
 | LLM fabricates a handle | Not in the map; lazy-adoption scan finds nothing; `INVALID_HANDLE`; LLM recovers the same way |
 | Handle evicted by the cleanup policy, then presented again much later | Treated as unknown; lazy adoption finds no branches (eviction requires zero branches); `INVALID_HANDLE`; LLM recovers the same way; no data lost |
 
-**Handle lifetime and cleanup** (decision record: update plan §3.7). With persistence, handles
-live across restarts, so the persisted state file must be bounded. A handle is eligible for
-eviction when **both** hold:
+**Handle lifetime and cleanup** (decision record: update plan §3.7). With persistence, handles live across restarts, so the persisted state file must be bounded. A handle is eligible for eviction when **both** hold:
 
-1. **It owns no branches** — all merged away by maintenance, or it never created any. A handle
-   with live branches must never be evicted: that would orphan its branch files and break
-   read-your-own-writes for its conversation.
-2. **It has been inactive longer than the retention window** — `handle.retention_days`, default
-   60 days since its last memory tool call. Baselines for a handle idle that long are very
-   unlikely to ever be consulted again.
+1. **It owns no branches** — all merged away by maintenance, or it never created any. A handle with live branches must never be evicted: that would orphan its branch files and break read-your-own-writes for its conversation.
+2. **It has been inactive longer than the retention window** — `handle.retention_days`, default 60 days since its last memory tool call. Baselines for a handle idle that long are very unlikely to ever be consulted again.
 
-**Multi-bridge note:** when more than one MCP client is deployed, a bridge evicts only handles
-recorded in its *own* state file; see [Section 3.25.4](#3254-per-client-state-files).
+**Multi-bridge note:** when more than one MCP client is deployed, a bridge evicts only handles recorded in its *own* state file; see [Section 3.25.4](#3254-per-client-state-files).
 
-Cleanup runs as the final sweep of every `memory_run_maintenance` call
-([Section 3.13](#313-tool-memory_run_maintenance)) — no separate timer, no background thread, the
-same user-controlled cadence as merging. Eviction removes the handle's entry from the in-memory
-map and from the next persisted write; it loses no data because an evictable handle had no
-branches by definition. The retention window is configurable: a user running many concurrent
-conversations might want it shorter; one who returns to old conversations, longer. Deferred to
-v1.x: a hard LRU cap on handle count as a backstop, and incremental (append-log) persistence if
-whole-file rewrites ever become a bottleneck.
+Cleanup runs as the final sweep of every `memory_run_maintenance` call ([Section 3.13](#313-tool-memory_run_maintenance)) — no separate timer, no background thread, the same user-controlled cadence as merging. Eviction removes the handle's entry from the in-memory map and from the next persisted write; it loses no data because an evictable handle had no branches by definition. The retention window is configurable: a user running many concurrent conversations might want it shorter; one who returns to old conversations, longer. Deferred to v1.x: a hard LRU cap on handle count as a backstop, and incremental (append-log) persistence if whole-file rewrites ever become a bottleneck.
 
 ### 3.15 Per-Handle Branching and Race Detection
 
-Branching is the mechanism that resolves the concurrent read-modify-write race condition without
-ever involving the LLM. When a write from one conversation would overwrite changes another
-conversation made since the writer last read the target, the bridge transparently redirects the
-write to a per-handle **branch file**. The base file is left unmodified; the writer's conversation
-continues to see (and build on) its own writes; the other conversation's data is preserved; and a
-later maintenance run semantically merges everything back together.
+Branching is the mechanism that resolves the concurrent read-modify-write race condition without ever involving the LLM. When a write from one conversation would overwrite changes another conversation made since the writer last read the target, the bridge transparently redirects the write to a per-handle **branch file**. The base file is left unmodified; the writer's conversation continues to see (and build on) its own writes; the other conversation's data is preserved; and a later maintenance run semantically merges everything back together.
 
-**Branches are invisible to the LLM.** The LLM never sees branch filenames, never participates in
-race detection, and is never told a branch exists. From its perspective, every read returns *the*
-current state of a target and every write succeeds. There is no `branch_created` flag in any
-response, no branch content in any read, and no branch vocabulary in any error message. This is
-the load-bearing abstraction of the redesign: the v1 design returned branch content to the LLM
-(annotated) and relied on skill instructions to interpret it; the memory-aware design handles the
-entire branch lifecycle in code.
+**Branches are invisible to the LLM.** The LLM never sees branch filenames, never participates in race detection, and is never told a branch exists. From its perspective, every read returns *the* current state of a target and every write succeeds. There is no `branch_created` flag in any response, no branch content in any read, and no branch vocabulary in any error message. This is the load-bearing abstraction of the redesign: the v1 design returned branch content to the LLM (annotated) and relied on skill instructions to interpret it; the memory-aware design handles the entire branch lifecycle in code.
 
-**The per-handle branch map.** The bridge maintains, per handle, the map
-`block name → branch file path` (part of `HandleState`, [Section 3.14](#314-handle-management)).
-An entry `(H, B)` means handle H has diverged from the base of B and owns a private branch of it.
+**The per-handle branch map.** The bridge maintains, per handle, the map `block name → branch file path` (part of `HandleState`, [Section 3.14](#314-handle-management)). An entry `(H, B)` means handle H has diverged from the base of B and owns a private branch of it.
 
 **Read routing** for `memory_get_*` from handle H on target B:
 
@@ -1167,36 +948,20 @@ An entry `(H, B)` means handle H has diverged from the base of B and owns a priv
 
 **Write routing** for `memory_write_*` from handle H on target B:
 
-- If the branch map has an entry for `(H, B)`: write to that branch file. No race detection is
-  needed — H already owns this branch, and nobody else writes to it.
-- Otherwise, compare the base file's current signature (ModTime + size) against H's read baseline
-  for B:
+- If the branch map has an entry for `(H, B)`: write to that branch file. No race detection is needed — H already owns this branch, and nobody else writes to it.
+- Otherwise, compare the base file's current signature (ModTime + size) against H's read baseline for B:
   - **Signatures match (no race):** write to the base file.
-  - **Signatures differ (race):** create a new branch file
-    (`B.branch-<H>-<timestamp>.<ext>`), record it in the branch map at `(H, B)`, trigger an
-    immediate persistence checkpoint (branch-map entries are the most important state not to
-    lose), and write to the branch.
-  - **H has no baseline for B and the base exists:** treated as a race — another conversation
-    created or modified the file since H could have seen it. This covers the simultaneous
-    first-write scenario where two conversations independently create the same new block: the
-    second writer branches rather than silently overwriting the first.
+  - **Signatures differ (race):** create a new branch file (`B.branch-<H>-<timestamp>.<ext>`), record it in the branch map at `(H, B)`, trigger an immediate persistence checkpoint (branch-map entries are the most important state not to lose), and write to the branch.
+  - **H has no baseline for B and the base exists:** treated as a race — another conversation created or modified the file since H could have seen it. This covers the simultaneous first-write scenario where two conversations independently create the same new block: the second writer branches rather than silently overwriting the first.
   - **The base does not exist:** true first-ever creation; no race is possible; create the base.
 
-This is the mechanism by which **read-your-own-writes** is preserved: once H's write to B lands in
-a branch, all subsequent reads and writes from H on B route through that branch. Other
-conversations continue to see the base.
+This is the mechanism by which **read-your-own-writes** is preserved: once H's write to B lands in a branch, all subsequent reads and writes from H on B route through that branch. Other conversations continue to see the base.
 
-**No branches of branches.** Once a branch exists for `(H, B)`, all future operations from H on B
-reuse it. A branch is never itself branched. The storage model stays flat: at any moment, a block
-has zero or more *peer* branches, each owned by exactly one handle.
+**No branches of branches.** Once a branch exists for `(H, B)`, all future operations from H on B reuse it. A branch is never itself branched. The storage model stays flat: at any moment, a block has zero or more *peer* branches, each owned by exactly one handle.
 
-**Appends never create branches** — see
-[Section 3.11](#311-tools-memory_get_block-memory_write_block-memory_append_block) for the
-serialized-append semantics and the branch-routing rule for handles that already own a branch.
+**Appends never create branches** — see [Section 3.11](#311-tools-memory_get_block-memory_write_block-memory_append_block) for the serialized-append semantics and the branch-routing rule for handles that already own a branch.
 
-**When branching does NOT occur:** if `branching.enabled` is `false` in the config (a debugging
-escape hatch), all writes use last-writer-wins semantics and no branches are created. If the
-signatures match, no race has occurred and the write proceeds to the base normally.
+**When branching does NOT occur:** if `branching.enabled` is `false` in the config (a debugging escape hatch), all writes use last-writer-wins semantics and no branches are created. If the signatures match, no race has occurred and the write proceeds to the base normally.
 
 **Branch file naming convention** (decision record: update plan §3.8):
 
@@ -1210,61 +975,31 @@ Examples:
 
 The convention is designed to be:
 
-- **Handle-embedding** — the owning handle appears in the filename, which (a) makes the
-  filesystem a partial backing store for the branch map, enabling the lazy-adoption recovery
-  backstop ([Section 3.18](#318-bridge-state-persistence-and-recovery)), and (b) makes branches
-  attributable by inspection: a human can see which conversation owns each branch. The handle
-  replaces the random hex suffix of the v1 convention with something meaningful. **Any future
-  change to this convention must preserve handle-recoverability from the filename, or accept that
-  lazy adoption stops working** (the persisted-state path would still function).
-- **Parseable** — `*.branch-<handle>-*.<ext>` globbing identifies a handle's branches; the handle
-  is the lookup key.
+- **Handle-embedding** — the owning handle appears in the filename, which (a) makes the filesystem a partial backing store for the branch map, enabling the lazy-adoption recovery backstop ([Section 3.18](#318-bridge-state-persistence-and-recovery)), and (b) makes branches attributable by inspection: a human can see which conversation owns each branch. The handle replaces the random hex suffix of the v1 convention with something meaningful. **Any future change to this convention must preserve handle-recoverability from the filename, or accept that lazy adoption stops working** (the persisted-state path would still function).
+- **Parseable** — `*.branch-<handle>-*.<ext>` globbing identifies a handle's branches; the handle is the lookup key.
 - **Windows-safe** — see the timestamp format below.
 
 **The embedded timestamp — what it means and how it behaves:**
 
-- **It is the branch's creation time** — the moment the bridge created the branch in response to
-  the first racing write for that `(handle, block)` pair.
-- **It is frozen at creation and never updated.** All subsequent writes by the same handle update
-  the branch's *contents*, not its *filename* (no branches of branches). The embedded timestamp
-  therefore means "when this conversation first diverged from the base," not "when the branch was
-  last modified" — last-modified comes from the filesystem's own mtime. This split is deliberate:
-  the bridge never has to rename a branch file (renaming on every write would add complexity and
-  could race with a lazy-adoption scan mid-rename).
-- **It is purely informational, for human debugging.** The bridge never parses or compares it;
-  lazy adoption matches by handle, and uniqueness is already guaranteed by the
-  `(handle, block)` pair. It is an annotation, not a key.
+- **It is the branch's creation time** — the moment the bridge created the branch in response to the first racing write for that `(handle, block)` pair.
+- **It is frozen at creation and never updated.** All subsequent writes by the same handle update the branch's *contents*, not its *filename* (no branches of branches). The embedded timestamp therefore means "when this conversation first diverged from the base," not "when the branch was last modified" — last-modified comes from the filesystem's own mtime. This split is deliberate: the bridge never has to rename a branch file (renaming on every write would add complexity and could race with a lazy-adoption scan mid-rename).
+- **It is purely informational, for human debugging.** The bridge never parses or compares it; lazy adoption matches by handle, and uniqueness is already guaranteed by the `(handle, block)` pair. It is an annotation, not a key.
 
-**Timestamp format — compact UTC with seconds and a `Z` suffix** (e.g., `20260520T142300Z`,
-meaning 2026-05-20 14:23:00 UTC):
+**Timestamp format — compact UTC with seconds and a `Z` suffix** (e.g., `20260520T142300Z`, meaning 2026-05-20 14:23:00 UTC):
 
-- **Compact (basic) ISO 8601**, not extended: no hyphens between date parts, no colons between
-  time parts, literal `T` separator retained. Colons are illegal in Windows filenames, and the
-  extended form's internal hyphens would collide — visually and programmatically — with the
-  hyphens this filename uses as its own field separators (`branch` - `<handle>` - `<timestamp>`).
-- **UTC with a trailing `Z`**: filename-safe (just a letter) and removes daylight-saving and
-  timezone ambiguity. The small loss of at-a-glance local readability is acceptable for a debug
-  annotation.
+- **Compact (basic) ISO 8601**, not extended: no hyphens between date parts, no colons between time parts, literal `T` separator retained. Colons are illegal in Windows filenames, and the extended form's internal hyphens would collide — visually and programmatically — with the hyphens this filename uses as its own field separators (`branch` - `<handle>` - `<timestamp>`).
+- **UTC with a trailing `Z`**: filename-safe (just a letter) and removes daylight-saving and timezone ambiguity. The small loss of at-a-glance local readability is acceptable for a debug annotation.
 - **Seconds included**: cheap, improves debug precision, removes same-minute ambiguity.
 
-**On-disk layout:** branches sit alongside their base files in the same directory (memory root
-for core, blocks directory for blocks). The layout is bridge-internal; the skill never references
-it.
+**On-disk layout:** branches sit alongside their base files in the same directory (memory root for core, blocks directory for blocks). The layout is bridge-internal; the skill never references it.
 
-**Expected frequency:** branching only occurs when two conversations are active simultaneously
-*and* both modify the same target after overlapping reads. The typical usage pattern — one active
-conversation at a time — produces zero branches. This changes materially in a multi-client
-deployment; see [Section 3.25.8](#3258-effect-on-branching-and-merging).
+**Expected frequency:** branching only occurs when two conversations are active simultaneously *and* both modify the same target after overlapping reads. The typical usage pattern — one active conversation at a time — produces zero branches. This changes materially in a multi-client deployment; see [Section 3.25.8](#3258-effect-on-branching-and-merging).
 
-**Multi-bridge note:** the routing rules above gain a self-healing precondition when a branch file
-has been merged away by a peer bridge, and the signature compared during write routing gains a
-content hash. Both are specified in [Section 3.25](#325-multi-bridge-concurrency); the branching
-algorithm itself is unchanged.
+**Multi-bridge note:** the routing rules above gain a self-healing precondition when a branch file has been merged away by a peer bridge, and the signature compared during write routing gains a content hash. Both are specified in [Section 3.25](#325-multi-bridge-concurrency); the branching algorithm itself is unchanged.
 
 ### 3.16 Block File Format and Atomic Writes
 
-**Block file format on disk.** Every block file carries YAML frontmatter holding the block's
-index metadata, followed by the markdown body:
+**Block file format on disk.** Every block file carries YAML frontmatter holding the block's index metadata, followed by the markdown body:
 
 ```yaml
 ---
@@ -1275,204 +1010,90 @@ updated_at: 2026-05-20T14:23:00Z
 ...
 ```
 
-The bridge manages the frontmatter transparently: `memory_get_block` strips it and returns only
-the body; `memory_write_block` composes frontmatter (new or preserved `summary`, `updated_at` set
-to now) plus the provided body and writes them as one file. The LLM never sees frontmatter. A
-human can — the metadata is inspectable at the top of any block file in a text editor.
+The bridge manages the frontmatter transparently: `memory_get_block` strips it and returns only the body; `memory_write_block` composes frontmatter (new or preserved `summary`, `updated_at` set to now) plus the provided body and writes them as one file. The LLM never sees frontmatter. A human can — the metadata is inspectable at the top of any block file in a text editor.
 
-Core (`core.md`) is the exception: it has **no frontmatter**. It is always loaded in full and
-does not appear in the index, so it needs no machine-readable metadata.
+Core (`core.md`) is the exception: it has **no frontmatter**. It is always loaded in full and does not appear in the index, so it needs no machine-readable metadata.
 
-**Schema evolution:** YAML frontmatter is naturally extensible. Adding fields (e.g., `importance`
-per [Chapter 9, Section 9.7](stateful-agent-design-chapter9.md#97-importance-scoring-on-blocks-and-episodic-entries))
-is backwards-compatible. Removing or renaming fields requires a migration sweep at bridge startup.
+**Schema evolution:** YAML frontmatter is naturally extensible. Adding fields (e.g., `importance` per [Chapter 9, Section 9.7](stateful-agent-design-chapter9.md#97-importance-scoring-on-blocks-and-episodic-entries)) is backwards-compatible. Removing or renaming fields requires a migration sweep at bridge startup.
 
-**Atomic write procedure.** With the index folded into block files, the v1 problem of atomically
-coordinating a block write with an index write reduces to an atomic *single-file* write — solvable
-with the standard temp-and-rename approach:
+**Atomic write procedure.** With the index folded into block files, the v1 problem of atomically coordinating a block write with an index write reduces to an atomic *single-file* write — solvable with the standard temp-and-rename approach:
 
-1. Determine the target file: base or branch for this handle, per
-   [Section 3.15](#315-per-handle-branching-and-race-detection).
-2. Compose the file content: frontmatter (`updated_at` = now; `summary` = the provided value, or
-   the previous summary preserved) plus the body. (For core: just the body.)
-3. Write the composed content to a temp file alongside the target (e.g., `<name>.md.tmp.<random>`),
-   in the same directory to guarantee a same-filesystem rename.
+1. Determine the target file: base or branch for this handle, per [Section 3.15](#315-per-handle-branching-and-race-detection).
+2. Compose the file content: frontmatter (`updated_at` = now; `summary` = the provided value, or the previous summary preserved) plus the body. (For core: just the body.)
+3. Write the composed content to a temp file alongside the target (e.g., `<name>.md.tmp.<random>`), in the same directory to guarantee a same-filesystem rename.
 4. `fsync` the temp file.
 5. Atomically rename temp → target.
 
-There is no second file to keep in sync: frontmatter and body are written together, so they can
-never diverge. This is materially simpler than the v1 design, which had to coordinate a block
-write with an `index.md` write; the simpler invariant is easier to verify and to recover.
+There is no second file to keep in sync: frontmatter and body are written together, so they can never diverge. This is materially simpler than the v1 design, which had to coordinate a block write with an `index.md` write; the simpler invariant is easier to verify and to recover.
 
-**Windows rename caveat:** `os.Rename` cannot atomically overwrite an existing file on all Windows
-filesystems. The v1-proven approach applies: remove the target if it exists, then rename — an
-acceptably tiny non-existence window given mutex-serialized, low-frequency writes. If true
-atomicity is needed later, the Windows `ReplaceFile` API can be called via `syscall`. **In a
-multi-bridge deployment this becomes mandatory rather than optional, and temp file names gain a
-client-id component so that one bridge's startup sweeper cannot delete a peer's in-flight temp
-file** — see [Sections 3.25.6](#3256-atomic-replace-on-windows) and
-[3.25.7](#3257-temp-file-naming-and-the-startup-sweeper).
+**Windows rename caveat:** `os.Rename` cannot atomically overwrite an existing file on all Windows filesystems. The v1-proven approach applies: remove the target if it exists, then rename — an acceptably tiny non-existence window given mutex-serialized, low-frequency writes. If true atomicity is needed later, the Windows `ReplaceFile` API can be called via `syscall`. **In a multi-bridge deployment this becomes mandatory rather than optional, and temp file names gain a client-id component so that one bridge's startup sweeper cannot delete a peer's in-flight temp file** — see [Sections 3.25.6](#3256-atomic-replace-on-windows) and [3.25.7](#3257-temp-file-naming-and-the-startup-sweeper).
 
 **Crash recovery (startup sweeper):**
 
 - Orphan temp files (`*.tmp.*`) older than a few seconds are deleted at bridge startup.
-- Branch files on disk that the loaded persisted state doesn't know about are picked up by the
-  startup lazy-adoption pass ([Section 3.18](#318-bridge-state-persistence-and-recovery)); branch
-  files whose handles are gone entirely simply wait for the next `memory_run_maintenance`, which
-  enumerates all branches on disk regardless of handle liveness. Data is preserved either way.
-- Block files missing required frontmatter (e.g., hand-edited by the user without preserving it)
-  get default frontmatter inserted on the next read or scheduled write — the bridge neither
-  silently loses the data nor refuses to read it. The default summary is derived mechanically
-  (e.g., the first heading or first line, truncated).
+- Branch files on disk that the loaded persisted state doesn't know about are picked up by the startup lazy-adoption pass ([Section 3.18](#318-bridge-state-persistence-and-recovery)); branch files whose handles are gone entirely simply wait for the next `memory_run_maintenance`, which enumerates all branches on disk regardless of handle liveness. Data is preserved either way.
+- Block files missing required frontmatter (e.g., hand-edited by the user without preserving it) get default frontmatter inserted on the next read or scheduled write — the bridge neither silently loses the data nor refuses to read it. The default summary is derived mechanically (e.g., the first heading or first line, truncated).
 
 ### 3.17 Merge Process and Merge Mutex
 
-The merge is the maintenance-time action that folds a block's peer branches back into a single
-canonical base. It runs only inside `memory_run_maintenance`
-([Section 3.13](#313-tool-memory_run_maintenance)). For each block with pending branches:
+The merge is the maintenance-time action that folds a block's peer branches back into a single canonical base. It runs only inside `memory_run_maintenance` ([Section 3.13](#313-tool-memory_run_maintenance)). For each block with pending branches:
 
 1. **Select** all peer branches of base block B, along with B itself.
-2. **Acquire the merge mutex**, blocking all other memory I/O for the duration of this block's
-   merge (see below).
-3. **Merge semantically via an LLM sub-agent.** The bridge invokes a sub-agent (a separate
-   `claude -p` process, reusing the spawn machinery internally) with the base content and all
-   branch contents, instructed to produce a single unified document. This is a *semantic* merge,
-   not a textual three-way merge: memory files are prose markdown, and a line-based merge would
-   produce incoherent results when two conversations independently rewrote the same paragraph.
-   The merger identifies what is unique to each version, what is shared, and what conflicts; for
-   conflicts (e.g., two different status updates for the same project), the chronologically
-   latest version is authoritative, but earlier information is preserved when it contains facts
-   absent from the later version. Branch creation timestamps (from filenames) and file mtimes
-   establish chronology. Simple merges (e.g., different episodic additions) can use a cheaper
-   model (Sonnet or Haiku); complex merges of `core.md` may warrant Opus.
-4. **Regenerate frontmatter.** The merged file's `summary` is typically derived by the sub-agent
-   from the merged body; `updated_at` is set to the merge time. (Core has no frontmatter.)
-5. **Atomically replace** the base file with the merged result
-   ([Section 3.16](#316-block-file-format-and-atomic-writes)).
+2. **Acquire the merge mutex**, blocking all other memory I/O for the duration of this block's merge (see below).
+3. **Merge semantically via an LLM sub-agent.** The bridge invokes a sub-agent (a separate `claude -p` process, reusing the spawn machinery internally) with the base content and all branch contents, instructed to produce a single unified document. This is a *semantic* merge, not a textual three-way merge: memory files are prose markdown, and a line-based merge would produce incoherent results when two conversations independently rewrote the same paragraph. The merger identifies what is unique to each version, what is shared, and what conflicts; for conflicts (e.g., two different status updates for the same project), the chronologically latest version is authoritative, but earlier information is preserved when it contains facts absent from the later version. Branch creation timestamps (from filenames) and file mtimes establish chronology. Simple merges (e.g., different episodic additions) can use a cheaper model (Sonnet or Haiku); complex merges of `core.md` may warrant Opus.
+4. **Regenerate frontmatter.** The merged file's `summary` is typically derived by the sub-agent from the merged body; `updated_at` is set to the merge time. (Core has no frontmatter.)
+5. **Atomically replace** the base file with the merged result ([Section 3.16](#316-block-file-format-and-atomic-writes)).
 6. **Delete** all branch files for B.
-7. **Clear** all branch-map entries `(*, B)` so future reads from every handle see the merged
-   base. Handles whose branches were merged away simply route back to the base; their read
-   baselines are refreshed on their next read.
+7. **Clear** all branch-map entries `(*, B)` so future reads from every handle see the merged base. Handles whose branches were merged away simply route back to the base; their read baselines are refreshed on their next read.
 8. **Release the mutex.**
 
-The merge work runs in sub-agents — separate LLM invocations dispatched by the bridge — not in the
-calling conversation's reasoning context, so the calling LLM never reasons about merge content. But
-the `memory_run_maintenance` call itself is **synchronous**: it returns only after the selected
-blocks' merges complete (bounded by the per-call cap of [Section 3.13](#313-tool-memory_run_maintenance)).
+The merge work runs in sub-agents — separate LLM invocations dispatched by the bridge — not in the calling conversation's reasoning context, so the calling LLM never reasons about merge content. But the `memory_run_maintenance` call itself is **synchronous**: it returns only after the selected blocks' merges complete (bounded by the per-call cap of [Section 3.13](#313-tool-memory_run_maintenance)).
 
-Note that this preserves the **single-writer model**: the merge sub-agent produces merged
-*content*, but the bridge itself performs the file replacement. Sub-agents still never write to
-memory (see [Chapter 6, Section 6.6](stateful-agent-design-chapter6.md#66-sub-agent-memory-access-rules)).
+Note that this preserves the **single-writer model**: the merge sub-agent produces merged *content*, but the bridge itself performs the file replacement. Sub-agents still never write to memory (see [Chapter 6, Section 6.6](stateful-agent-design-chapter6.md#66-sub-agent-memory-access-rules)).
 
-**The merge mutex.** While a block's merge is in progress, the bridge holds a lock that blocks
-all `memory_*` tool calls touching that block — preventing new branches from being created
-mid-merge and preventing reads from observing partial merge state. For v1 simplicity, the lock is
-the existing process-wide memory mutex held for the duration of each block's merge; a
-finer-grained per-block lock is a future optimization. Because merges run only when the user
-invokes maintenance — typically at a moment chosen for the purpose — the practical impact of
-process-wide locking is small. A blocked caller that would wait unacceptably long receives
-`MAINTENANCE_IN_PROGRESS` ([Section 3.19](#319-error-response-convention)) rather than hanging.
+**The merge mutex.** While a block's merge is in progress, the bridge holds a lock that blocks all `memory_*` tool calls touching that block — preventing new branches from being created mid-merge and preventing reads from observing partial merge state. For v1 simplicity, the lock is the existing process-wide memory mutex held for the duration of each block's merge; a finer-grained per-block lock is a future optimization. Because merges run only when the user invokes maintenance — typically at a moment chosen for the purpose — the practical impact of process-wide locking is small. A blocked caller that would wait unacceptably long receives `MAINTENANCE_IN_PROGRESS` ([Section 3.19](#319-error-response-convention)) rather than hanging.
 
-**The memory mutex (ordinary operation).** Outside of merges, all memory tool handlers serialize
-on a single process-wide `sync.Mutex` (`memmutex.go`), exactly as in v1: reads acquire it so the
-signature recorded for a read is consistent with the content returned; writes acquire it so
-signature-compare-then-write sequences are atomic with respect to other conversations. A single
-mutex (rather than per-file locks) keeps the implementation trivial and deadlock-free; memory I/O
-is infrequent and sub-millisecond, so the serialization cost is negligible.
+**The memory mutex (ordinary operation).** Outside of merges, all memory tool handlers serialize on a single process-wide `sync.Mutex` (`memmutex.go`), exactly as in v1: reads acquire it so the signature recorded for a read is consistent with the content returned; writes acquire it so signature-compare-then-write sequences are atomic with respect to other conversations. A single mutex (rather than per-file locks) keeps the implementation trivial and deadlock-free; memory I/O is infrequent and sub-millisecond, so the serialization cost is negligible.
 
-**Both mutexes described above are process-local and therefore insufficient once more than one MCP
-client is deployed.** [Section 3.25.3](#3253-the-cross-process-memory-lock) layers an OS-level
-advisory file lock beneath them, retaining the in-process mutexes as the fast path.
+**Both mutexes described above are process-local and therefore insufficient once more than one MCP client is deployed.** [Section 3.25.3](#3253-the-cross-process-memory-lock) layers an OS-level advisory file lock beneath them, retaining the in-process mutexes as the fast path.
 
 ### 3.18 Bridge State Persistence and Recovery
 
-The bridge persists its in-memory state to disk and reloads it at startup. Motivation: the bridge
-is spawned by Claude Desktop over stdio and **terminates on every Claude Desktop close**
-([Section 3.24](#324-graceful-shutdown)) — so in-memory-only state would be discarded routinely,
-not rarely. Without persistence, every close-reopen cycle would degrade race detection and the
-`changed_since_last_read` flag (read baselines are not recoverable from disk). With persistence, a
-restart is transparent. (Decision record: update plan §2.12, which superseded an earlier
-in-memory-only decision.)
+The bridge persists its in-memory state to disk and reloads it at startup. Motivation: the bridge is spawned by Claude Desktop over stdio and **terminates on every Claude Desktop close** ([Section 3.24](#324-graceful-shutdown)) — so in-memory-only state would be discarded routinely, not rarely. Without persistence, every close-reopen cycle would degrade race detection and the `changed_since_last_read` flag (read baselines are not recoverable from disk). With persistence, a restart is transparent. (Decision record: update plan §2.12, which superseded an earlier in-memory-only decision.)
 
-**What is persisted** — the three pieces of per-conversation state the bridge tracks, plus the
-bookkeeping needed by the eviction policy:
+**What is persisted** — the three pieces of per-conversation state the bridge tracks, plus the bookkeeping needed by the eviction policy:
 
-1. The set of live handles, each with its last-activity time
-   ([Section 3.14](#314-handle-management)).
+1. The set of live handles, each with its last-activity time ([Section 3.14](#314-handle-management)).
 2. The per-handle branch map (`handle → block name → branch file path`).
 3. The per-handle read baselines (`handle → block name → content signature`).
 
-The branch *files* themselves remain the source of truth for branch content; the state file
-records only the mapping and metadata. Because branch filenames also embed the handle
-([Section 3.15](#315-per-handle-branching-and-race-detection)), the branch→handle association is
-independently recoverable from disk even if the state file is lost — which is exactly what makes
-lazy adoption a viable backstop.
+The branch *files* themselves remain the source of truth for branch content; the state file records only the mapping and metadata. Because branch filenames also embed the handle ([Section 3.15](#315-per-handle-branching-and-race-detection)), the branch→handle association is independently recoverable from disk even if the state file is lost — which is exactly what makes lazy adoption a viable backstop.
 
-**Storage location and format.** A single JSON file in the memory root, named
-`.bridge-state.json` (leading dot so it sorts away from memory content and is visually distinct
-from blocks). It is bridge-private: neither the LLM nor the SKILL ever references it, and it is
-not memory content.
+**Storage location and format.** A single JSON file in the memory root, named `.bridge-state.json` (leading dot so it sorts away from memory content and is visually distinct from blocks). It is bridge-private: neither the LLM nor the SKILL ever references it, and it is not memory content.
 
 **Write strategy:**
 
-- **On clean shutdown**, when the bridge detects EOF on stdin (the normal Claude Desktop close
-  path — [Section 3.24](#324-graceful-shutdown)). This is the common case and captures the most
-  recent state.
-- **Debounced checkpoints during operation:** state-changing operations mark the state dirty;
-  changes are coalesced and flushed at most once per `persistence.checkpoint_interval_seconds`
-  (default 5), so a burst of writes doesn't cause a burst of disk I/O. **Branch creation triggers
-  an immediate checkpoint** — the branch-map entry is the most important state not to lose, since
-  losing it (plus the state file) is what creates recovery work.
-- **Whole-file rewrite each time**, via the same temp-file-plus-atomic-rename pattern as block
-  writes ([Section 3.16](#316-block-file-format-and-atomic-writes)), so a crash mid-write cannot
-  corrupt the file. For the expected state size (at most a few hundred handles, each small) a
-  whole-file JSON rewrite is well under a millisecond; incremental/append-based persistence is a
-  v1.x optimization.
+- **On clean shutdown**, when the bridge detects EOF on stdin (the normal Claude Desktop close path — [Section 3.24](#324-graceful-shutdown)). This is the common case and captures the most recent state.
+- **Debounced checkpoints during operation:** state-changing operations mark the state dirty; changes are coalesced and flushed at most once per `persistence.checkpoint_interval_seconds` (default 5), so a burst of writes doesn't cause a burst of disk I/O. **Branch creation triggers an immediate checkpoint** — the branch-map entry is the most important state not to lose, since losing it (plus the state file) is what creates recovery work.
+- **Whole-file rewrite each time**, via the same temp-file-plus-atomic-rename pattern as block writes ([Section 3.16](#316-block-file-format-and-atomic-writes)), so a crash mid-write cannot corrupt the file. For the expected state size (at most a few hundred handles, each small) a whole-file JSON rewrite is well under a millisecond; incremental/append-based persistence is a v1.x optimization.
 
 **Load and reconcile at startup:**
 
 1. Load `.bridge-state.json` if present.
-2. **Reconcile against the filesystem:** for each persisted branch-map entry, verify the
-   referenced branch file still exists; drop entries whose files are gone (e.g., merged away by a
-   maintenance run from a different bridge instance — rare in a single-bridge deployment).
-3. **Run lazy adoption as a backstop:** scan the memory directory for branch files *not*
-   represented in the loaded state and rebuild map entries for them from the handle embedded in
-   each filename. This covers a stale state file (branch created after the last checkpoint), a
-   missing one, and a corrupt one.
+2. **Reconcile against the filesystem:** for each persisted branch-map entry, verify the referenced branch file still exists; drop entries whose files are gone (e.g., merged away by a maintenance run from a different bridge instance — rare in a single-bridge deployment).
+3. **Run lazy adoption as a backstop:** scan the memory directory for branch files *not* represented in the loaded state and rebuild map entries for them from the handle embedded in each filename. This covers a stale state file (branch created after the last checkpoint), a missing one, and a corrupt one.
 
-**Persistence is the primary recovery mechanism; lazy adoption is the reconciliation backstop.**
-Lazy adoption runs in two places: the startup pass above, and the unknown-handle path of
-[Section 3.14](#314-handle-management) (a well-formed handle absent from the loaded state). What
-lazy adoption can recover is the branch map — the handle→branch association is in the filenames.
-What it cannot recover is read baselines, which exist only in the state file; after
-adoption-without-state, the affected handle's first read of each target sets a fresh baseline
-(`changed_since_last_read: false`, matching a fresh handle), and its first write may miss one race
-(one cross-conversation overwrite per restart per affected block — bounded and small; the stricter
-alternative of always branching the first post-recovery write would produce spurious branches
-every restart, costing more than it gains). The system therefore recovers full state in the normal
-case and degrades gracefully — never below the pre-persistence design — when the state file is
-unavailable.
+**Persistence is the primary recovery mechanism; lazy adoption is the reconciliation backstop.** Lazy adoption runs in two places: the startup pass above, and the unknown-handle path of [Section 3.14](#314-handle-management) (a well-formed handle absent from the loaded state). What lazy adoption can recover is the branch map — the handle→branch association is in the filenames. What it cannot recover is read baselines, which exist only in the state file; after adoption-without-state, the affected handle's first read of each target sets a fresh baseline (`changed_since_last_read: false`, matching a fresh handle), and its first write may miss one race (one cross-conversation overwrite per restart per affected block — bounded and small; the stricter alternative of always branching the first post-recovery write would produce spurious branches every restart, costing more than it gains). The system therefore recovers full state in the normal case and degrades gracefully — never below the pre-persistence design — when the state file is unavailable.
 
-**Corruption handling.** If `.bridge-state.json` is present but unparseable, the bridge logs the
-problem to its server-side log, discards the corrupt file, and falls back to pure lazy adoption.
-The bridge is never worse off than a lazy-adoption-only design, even in the corruption case.
+**Corruption handling.** If `.bridge-state.json` is present but unparseable, the bridge logs the problem to its server-side log, discards the corrupt file, and falls back to pure lazy adoption. The bridge is never worse off than a lazy-adoption-only design, even in the corruption case.
 
-**Eviction interplay:** the cleanup sweep of [Section 3.14](#314-handle-management) removes
-evicted handles from the in-memory map; they disappear from the state file at its next write.
+**Eviction interplay:** the cleanup sweep of [Section 3.14](#314-handle-management) removes evicted handles from the in-memory map; they disappear from the state file at its next write.
 
-**Multi-bridge revision.** Everything above describes a single bridge owning a single
-`.bridge-state.json`. When two or more MCP clients are deployed, that file is partitioned into one
-file per client and the load-and-reconcile procedure is extended accordingly; a whole-file rewrite
-by one bridge would otherwise destroy the other's handles, branch map, and baselines. See
-[Section 3.25.4](#3254-per-client-state-files).
+**Multi-bridge revision.** Everything above describes a single bridge owning a single `.bridge-state.json`. When two or more MCP clients are deployed, that file is partitioned into one file per client and the load-and-reconcile procedure is extended accordingly; a whole-file rewrite by one bridge would otherwise destroy the other's handles, branch map, and baselines. See [Section 3.25.4](#3254-per-client-state-files).
 
 ### 3.19 Error Response Convention
 
-Traditional programming APIs tended toward terse, machine-only error codes (`ENOENT`) because the
-consumer was other code that couldn't usefully act on free-form text. LLMs collapse that gap — the
-error *message* itself is the recovery instruction. The bridge's memory tools therefore return
-errors with both a stable machine-readable code and a natural-language message. (Decision record:
-update plan §3.10.)
+Traditional programming APIs tended toward terse, machine-only error codes (`ENOENT`) because the consumer was other code that couldn't usefully act on free-form text. LLMs collapse that gap — the error *message* itself is the recovery instruction. The bridge's memory tools therefore return errors with both a stable machine-readable code and a natural-language message. (Decision record: update plan §3.10.)
 
 **Schema:**
 
@@ -1491,16 +1112,10 @@ update plan §3.10.)
 
 **Why both `code` and `message`:**
 
-- The `message` gives the LLM a natural-language explanation it can act on directly, without the
-  SKILL having to enumerate every error code and recovery procedure.
-- The `code` stays stable across message rewordings. Tests, future tooling, and automated handling
-  can rely on `INVALID_HANDLE` even if the message text is later improved, and the code is
-  grep-able in server logs without false matches.
+- The `message` gives the LLM a natural-language explanation it can act on directly, without the SKILL having to enumerate every error code and recovery procedure.
+- The `code` stays stable across message rewordings. Tests, future tooling, and automated handling can rely on `INVALID_HANDLE` even if the message text is later improved, and the code is grep-able in server logs without false matches.
 
-**Abstraction discipline (critical):** error messages must respect the layers established by the
-design. The LLM operates on *handles*, *core*, *blocks*, *summaries*, and *the index*. Branches,
-mutexes, frontmatter, file paths, the branch map, and every other implementation detail are
-bridge-internal and must not appear in error messages.
+**Abstraction discipline (critical):** error messages must respect the layers established by the design. The LLM operates on *handles*, *core*, *blocks*, *summaries*, and *the index*. Branches, mutexes, frontmatter, file paths, the branch map, and every other implementation detail are bridge-internal and must not appear in error messages.
 
 Good error messages:
 - ✅ `"Block 'foo' does not exist for this handle"` — speaks at the block abstraction.
@@ -1514,13 +1129,9 @@ Bad error messages (leak the design):
 - ❌ `"Frontmatter parse failed at line 3"`
 - ❌ `"Failed to atomic-rename temp file"`
 
-For internal errors the LLM cannot recover from (disk failure, invariant violation, sub-agent
-merge failure), the message stays generic — *"An internal bridge error occurred; the operation was
-not completed. Please report this to the user."* — and the technical detail goes to the
-server-side log file ([Section 3.22](#322-logging)) for the user to inspect when debugging.
+For internal errors the LLM cannot recover from (disk failure, invariant violation, sub-agent merge failure), the message stays generic — *"An internal bridge error occurred; the operation was not completed. Please report this to the user."* — and the technical detail goes to the server-side log file ([Section 3.22](#322-logging)) for the user to inspect when debugging.
 
-**Initial error code set** (a starting point, not exhaustive; new codes are added as new error
-situations are identified):
+**Initial error code set** (a starting point, not exhaustive; new codes are added as new error situations are identified):
 
 | Code | Meaning |
 |---|---|
@@ -1534,10 +1145,7 @@ situations are identified):
 | `MEMORY_BUSY` | Another memory operation is holding memory I/O longer than the configured wait; retry shortly. In a multi-client deployment this includes contention with a peer bridge ([Section 3.25.3](#3253-the-cross-process-memory-lock)) |
 | `INTERNAL_ERROR` | Catch-all; the message stays generic; details go to the server log |
 
-**Schema-validation errors:** if MCP itself rejects a call (e.g., the required `handle` parameter
-omitted), the error shape is whatever MCP returns and is not under the bridge's control. The SKILL
-teaches one recovery for any handle-related rejection — schema-level or bridge-issued: call
-`memory_start_conversation`, retry.
+**Schema-validation errors:** if MCP itself rejects a call (e.g., the required `handle` parameter omitted), the error shape is whatever MCP returns and is not under the bridge's control. The SKILL teaches one recovery for any handle-related rejection — schema-level or bridge-issued: call `memory_start_conversation`, retry.
 
 ### 3.20 Async Executor
 
@@ -1731,10 +1339,7 @@ All bridge operations are logged to a file for auditability and debugging. Loggi
 | Error (any) | error | tool name, error code, error details |
 | Bridge shutdown | info | active jobs killed, final state checkpoint written |
 
-Note that branch filenames, frontmatter problems, and other implementation details **do** appear
-in the log — the abstraction discipline of [Section 3.19](#319-error-response-convention) applies
-to tool responses, not to the server-side log, which exists precisely so the user can see the
-machinery when debugging.
+Note that branch filenames, frontmatter problems, and other implementation details **do** appear in the log — the abstraction discipline of [Section 3.19](#319-error-response-convention) applies to tool responses, not to the server-side log, which exists precisely so the user can see the machinery when debugging.
 
 **Format:** Structured JSON lines (one JSON object per log line). This is easy to parse, grep, and pipe into log aggregation tools.
 
@@ -1800,39 +1405,20 @@ func main():
 
 ### 3.25 Multi-Bridge Concurrency
 
-Every MCP client that registers the bridge spawns its **own** copy of the binary as a stdio child
-process. Supporting Claude Code alongside Claude Desktop ([Section 7.8](stateful-agent-design-chapter7.md#78-claude-code-deployment))
-therefore means two or more bridge processes running simultaneously against a single shared memory
-root. Nothing about the MCP protocol makes those processes aware of one another: each has its own
-handle map, its own mutexes, and its own view of what is on disk.
+Every MCP client that registers the bridge spawns its **own** copy of the binary as a stdio child process. Supporting Claude Code alongside Claude Desktop ([Section 7.8](stateful-agent-design-chapter7.md#78-claude-code-deployment)) therefore means two or more bridge processes running simultaneously against a single shared memory root. Nothing about the MCP protocol makes those processes aware of one another: each has its own handle map, its own mutexes, and its own view of what is on disk.
 
-This section defines what must change for that to be correct. It is written as a delta against
-Sections 3.14–3.18, which describe the single-bridge behavior; those sections remain accurate for
-a one-client deployment, and each now carries a pointer here.
+This section defines what must change for that to be correct. It is written as a delta against Sections 3.14–3.18, which describe the single-bridge behavior; those sections remain accurate for a one-client deployment, and each now carries a pointer here.
 
 #### 3.25.1 What the Existing Design Already Gets Right
 
-It is worth stating plainly what does *not* need to change, because it is more than one might
-expect, and it constrains how invasive the fix should be.
+It is worth stating plainly what does *not* need to change, because it is more than one might expect, and it constrains how invasive the fix should be.
 
-- **Branch ownership never crosses processes.** A branch belongs to exactly one handle, a handle
-  belongs to exactly one conversation, and a conversation lives inside exactly one client. Two
-  bridges therefore never write the same branch file. The flat peer-branch storage model of
-  [Section 3.15](#315-per-handle-branching-and-race-detection) survives multi-bridge operation
-  unchanged.
-- **Race detection already consults the filesystem, not memory.** The signature comparison reads
-  the base file's current on-disk state rather than a cached in-process value, so it observes
-  writes made by a *peer* bridge exactly as it observes writes made by another conversation in
-  the same bridge. The detection mechanism is already cross-process; only its atomicity is not.
-- **Branch filenames embed the owning handle.** Lazy adoption ([Section 3.18](#318-bridge-state-persistence-and-recovery))
-  reconstructs the handle→branch association from the filesystem alone, which means a bridge can
-  correctly interpret branch files created by a peer it knows nothing about.
-- **Maintenance already enumerates branches regardless of handle liveness.** The merge process of
-  [Section 3.17](#317-merge-process-and-merge-mutex) folds in every peer branch of a block found
-  on disk, so a merge run from one client correctly incorporates branches created by another.
+- **Branch ownership never crosses processes.** A branch belongs to exactly one handle, a handle belongs to exactly one conversation, and a conversation lives inside exactly one client. Two bridges therefore never write the same branch file. The flat peer-branch storage model of [Section 3.15](#315-per-handle-branching-and-race-detection) survives multi-bridge operation unchanged.
+- **Race detection already consults the filesystem, not memory.** The signature comparison reads the base file's current on-disk state rather than a cached in-process value, so it observes writes made by a *peer* bridge exactly as it observes writes made by another conversation in the same bridge. The detection mechanism is already cross-process; only its atomicity is not.
+- **Branch filenames embed the owning handle.** Lazy adoption ([Section 3.18](#318-bridge-state-persistence-and-recovery)) reconstructs the handle→branch association from the filesystem alone, which means a bridge can correctly interpret branch files created by a peer it knows nothing about.
+- **Maintenance already enumerates branches regardless of handle liveness.** The merge process of [Section 3.17](#317-merge-process-and-merge-mutex) folds in every peer branch of a block found on disk, so a merge run from one client correctly incorporates branches created by another.
 
-The consequence is that the *algorithms* are sound and the *serialization* is not. The changes
-below are almost entirely about locking, state-file ownership, and a few file-naming details.
+The consequence is that the *algorithms* are sound and the *serialization* is not. The changes below are almost entirely about locking, state-file ownership, and a few file-naming details.
 
 #### 3.25.2 What Breaks Without Changes
 
@@ -1848,52 +1434,26 @@ below are almost entirely about locking, state-file ownership, and a few file-na
 
 #### 3.25.3 The Cross-Process Memory Lock
 
-All memory file I/O is serialized across bridge processes by an **OS-level advisory lock** taken on
-a dedicated zero-length file, `.bridge-lock`, in the memory root.
+All memory file I/O is serialized across bridge processes by an **OS-level advisory lock** taken on a dedicated zero-length file, `.bridge-lock`, in the memory root.
 
-The choice of an OS lock over a hand-rolled lockfile (one containing a PID, say) is deliberate and
-load-bearing: **the operating system releases the lock automatically when the holding process
-terminates, for any reason, including a hard kill or a crash.** That single property eliminates the
-entire category of stale-lock recovery logic — no PID liveness probes, no lock expiry heuristics,
-no "is that process really dead?" ambiguity. Given that these bridges are killed routinely (Claude
-Desktop terminates its child on close, per [Section 3.24](#324-graceful-shutdown)), crash-safety by
-construction is worth far more here than it would be in a long-lived server.
+The choice of an OS lock over a hand-rolled lockfile (one containing a PID, say) is deliberate and load-bearing: **the operating system releases the lock automatically when the holding process terminates, for any reason, including a hard kill or a crash.** That single property eliminates the entire category of stale-lock recovery logic — no PID liveness probes, no lock expiry heuristics, no "is that process really dead?" ambiguity. Given that these bridges are killed routinely (Claude Desktop terminates its child on close, per [Section 3.24](#324-graceful-shutdown)), crash-safety by construction is worth far more here than it would be in a long-lived server.
 
 Implementation:
 
-- **Windows:** `LockFileEx` with `LOCKFILE_EXCLUSIVE_LOCK`, taken on a fixed byte range of
-  `.bridge-lock`, via `golang.org/x/sys/windows`.
-- **POSIX:** `flock(2)` with `LOCK_EX`, via `golang.org/x/sys/unix`. Included because portability
-  costs little here and the system may be packaged for general release; `flock` is preferred over
-  POSIX record locks (`fcntl`), whose release-on-any-close-in-the-process semantics are a
-  well-known hazard.
+- **Windows:** `LockFileEx` with `LOCKFILE_EXCLUSIVE_LOCK`, taken on a fixed byte range of `.bridge-lock`, via `golang.org/x/sys/windows`.
+- **POSIX:** `flock(2)` with `LOCK_EX`, via `golang.org/x/sys/unix`. Included because portability costs little here and the system may be packaged for general release; `flock` is preferred over POSIX record locks (`fcntl`), whose release-on-any-close-in-the-process semantics are a well-known hazard.
 
-**Two-level locking.** The existing in-process `sync.Mutex` is retained and acquired *first*, then
-the file lock. The in-process mutex is cheap and serializes this bridge's own goroutines without
-touching the filesystem; the file lock is acquired only once contention has already been resolved
-locally. The ordering is fixed and uniform, so no deadlock is possible. Release is in reverse
-order.
+**Two-level locking.** The existing in-process `sync.Mutex` is retained and acquired *first*, then the file lock. The in-process mutex is cheap and serializes this bridge's own goroutines without touching the filesystem; the file lock is acquired only once contention has already been resolved locally. The ordering is fixed and uniform, so no deadlock is possible. Release is in reverse order.
 
-**Scope of the lock.** It is held for the whole of any sequence that must be atomic with respect to
-peers:
+**Scope of the lock.** It is held for the whole of any sequence that must be atomic with respect to peers:
 
-1. The read path, from signature capture through content return, so the baseline recorded for a
-   read matches the content actually returned.
-2. The write path, from signature comparison through the atomic replace, so the branch/no-branch
-   decision cannot be invalidated between the decision and the write.
+1. The read path, from signature capture through content return, so the baseline recorded for a read matches the content actually returned.
+2. The write path, from signature comparison through the atomic replace, so the branch/no-branch decision cannot be invalidated between the decision and the write.
 3. The entire duration of each block's merge ([Section 3.17](#317-merge-process-and-merge-mutex)).
 
-**Acquisition timeout.** A new config key, `locking.acquire_timeout_seconds` (default 10), bounds
-how long a bridge waits. On expiry the tool returns `MEMORY_BUSY`
-([Section 3.19](#319-error-response-convention)) rather than hanging — a caller blocked behind a
-peer's long-running merge gets a clear, retryable error instead of a stalled conversation. The
-timeout must exceed the longest expected merge, which is itself bounded by the per-call merge cap
-of [Section 3.13](#313-tool-memory_run_maintenance).
+**Acquisition timeout.** A new config key, `locking.acquire_timeout_seconds` (default 10), bounds how long a bridge waits. On expiry the tool returns `MEMORY_BUSY` ([Section 3.19](#319-error-response-convention)) rather than hanging — a caller blocked behind a peer's long-running merge gets a clear, retryable error instead of a stalled conversation. The timeout must exceed the longest expected merge, which is itself bounded by the per-call merge cap of [Section 3.13](#313-tool-memory_run_maintenance).
 
-Per the abstraction-discipline rule of [Section 3.19](#319-error-response-convention), neither the
-code nor its message may reveal that locking or multiple bridge processes exist. `MEMORY_BUSY`
-carries a message such as *"Memory is busy; please retry in a moment"* — true at the block
-abstraction, and actionable without exposing anything internal.
+Per the abstraction-discipline rule of [Section 3.19](#319-error-response-convention), neither the code nor its message may reveal that locking or multiple bridge processes exist. `MEMORY_BUSY` carries a message such as *"Memory is busy; please retry in a moment"* — true at the block abstraction, and actionable without exposing anything internal.
 
 #### 3.25.4 Per-Client State Files
 
@@ -1903,45 +1463,22 @@ The single `.bridge-state.json` is replaced by **one state file per client**:
 .bridge-state-<client-id>.json
 ```
 
-`client-id` is supplied by a new `--client-id` command-line flag (equivalently `client.id` in
-`bridge-config.yaml`), defaulting to `desktop` for backward compatibility. It must be
-filename-safe (`[a-z0-9-]{1,32}`) and, critically, **stable across restarts of the same client** —
-it identifies the client, not the process instance. A bridge launched by Claude Desktop uses
-`desktop`; one launched by Claude Code uses `claude-code`.
+`client-id` is supplied by a new `--client-id` command-line flag (equivalently `client.id` in `bridge-config.yaml`), defaulting to `desktop` for backward compatibility. It must be filename-safe (`[a-z0-9-]{1,32}`) and, critically, **stable across restarts of the same client** — it identifies the client, not the process instance. A bridge launched by Claude Desktop uses `desktop`; one launched by Claude Code uses `claude-code`.
 
-This partitioning is what makes checkpointing safe *without* taking the memory lock. Handles are
-owned by exactly one client, so the per-client files have disjoint contents and exactly one writer
-each. The debounced checkpoint of [Section 3.18](#318-bridge-state-persistence-and-recovery) fires
-every few seconds; forcing it to contend with memory I/O on the shared lock would be both wasteful
-and a source of avoidable latency. Partitioning removes the contention entirely rather than
-managing it.
+This partitioning is what makes checkpointing safe *without* taking the memory lock. Handles are owned by exactly one client, so the per-client files have disjoint contents and exactly one writer each. The debounced checkpoint of [Section 3.18](#318-bridge-state-persistence-and-recovery) fires every few seconds; forcing it to contend with memory I/O on the shared lock would be both wasteful and a source of avoidable latency. Partitioning removes the contention entirely rather than managing it.
 
 **Startup load and reconcile**, revised:
 
 1. Load this bridge's own `.bridge-state-<client-id>.json`.
-2. Reconcile it against the filesystem exactly as before: drop branch-map entries whose branch
-   files no longer exist. Note that in a multi-bridge deployment this case is no longer rare —
-   a peer's maintenance run legitimately merges away and deletes this client's branches.
-3. Read peer state files (`.bridge-state-*.json`, excluding this client's) **read-only**, solely
-   to learn which handles are owned elsewhere. This informs eviction and handle minting. A bridge
-   never writes a peer's file.
+2. Reconcile it against the filesystem exactly as before: drop branch-map entries whose branch files no longer exist. Note that in a multi-bridge deployment this case is no longer rare — a peer's maintenance run legitimately merges away and deletes this client's branches.
+3. Read peer state files (`.bridge-state-*.json`, excluding this client's) **read-only**, solely to learn which handles are owned elsewhere. This informs eviction and handle minting. A bridge never writes a peer's file.
 4. Run lazy adoption as before, over branch files not represented in *any* loaded state.
 
-**Migration.** On first startup, a bridge finding a legacy `.bridge-state.json` renames it to
-`.bridge-state-<client-id>.json` using its own client id, then proceeds. Since the legacy file
-could only have been produced by a single-client deployment, attributing it to the current client
-is correct in every realistic case, and harmless otherwise (the worst outcome is lost baselines,
-which degrades exactly as a missing state file already does).
+**Migration.** On first startup, a bridge finding a legacy `.bridge-state.json` renames it to `.bridge-state-<client-id>.json` using its own client id, then proceeds. Since the legacy file could only have been produced by a single-client deployment, attributing it to the current client is correct in every realistic case, and harmless otherwise (the worst outcome is lost baselines, which degrades exactly as a missing state file already does).
 
-**Eviction, revised.** A bridge evicts only handles present in its *own* state file. It never
-evicts a handle it learned about from a peer's file, because it cannot observe that handle's
-activity and has no authority over its lifetime. The eligibility rules of
-[Section 3.14](#314-handle-management) are otherwise unchanged.
+**Eviction, revised.** A bridge evicts only handles present in its *own* state file. It never evicts a handle it learned about from a peer's file, because it cannot observe that handle's activity and has no authority over its lifetime. The eligibility rules of [Section 3.14](#314-handle-management) are otherwise unchanged.
 
-**Handle minting, revised.** The collision check of [Section 3.8](#38-tool-memory_start_conversation)
-consults the union of this bridge's handles and those read from peer state files. Minting is rare
-(once per conversation), so performing it under the memory lock with a fresh re-read of peer files
-costs nothing measurable and restores the guarantee the check is supposed to provide.
+**Handle minting, revised.** The collision check of [Section 3.8](#38-tool-memory_start_conversation) consults the union of this bridge's handles and those read from peer state files. Minting is rare (once per conversation), so performing it under the memory lock with a fresh re-read of peer files costs nothing measurable and restores the guarantee the check is supposed to provide.
 
 #### 3.25.5 Strengthening the Read Baseline Signature
 
@@ -1955,28 +1492,15 @@ type Signature struct {
 }
 ```
 
-Comparison uses `Hash` as the authoritative discriminator; `ModTime` and `Size` are retained for
-cheap early-out and for human debugging.
+Comparison uses `Hash` as the authoritative discriminator; `ModTime` and `Size` are retained for cheap early-out and for human debugging.
 
-The motivation is that ModTime-plus-size is a materially weaker discriminator once independent
-processes are writing. Windows filesystem timestamp granularity, combined with a rewrite that
-happens to produce the same file size — hardly exotic for prose blocks edited in place — yields a
-false "signatures match," which the write path reads as "no race" and resolves by overwriting the
-base. That is precisely the silent data loss branching exists to prevent, so paying a SHA-256 over
-a file that is at most a few tens of kilobytes, on operations that occur at conversational
-frequency, is an obviously good trade.
+The motivation is that ModTime-plus-size is a materially weaker discriminator once independent processes are writing. Windows filesystem timestamp granularity, combined with a rewrite that happens to produce the same file size — hardly exotic for prose blocks edited in place — yields a false "signatures match," which the write path reads as "no race" and resolves by overwriting the base. That is precisely the silent data loss branching exists to prevent, so paying a SHA-256 over a file that is at most a few tens of kilobytes, on operations that occur at conversational frequency, is an obviously good trade.
 
 #### 3.25.6 Atomic Replace on Windows
 
-The remove-then-rename fallback described in [Section 3.16](#316-block-file-format-and-atomic-writes)
-is **no longer acceptable**. Its justification was that the non-existence window is tiny and
-mutex-serialized; with peers holding no such mutex, a concurrent read can land inside the window
-and observe a block as missing, which the caller would interpret as "this block does not exist."
+The remove-then-rename fallback described in [Section 3.16](#316-block-file-format-and-atomic-writes) is **no longer acceptable**. Its justification was that the non-existence window is tiny and mutex-serialized; with peers holding no such mutex, a concurrent read can land inside the window and observe a block as missing, which the caller would interpret as "this block does not exist."
 
-The bridge must therefore use a genuinely atomic replace: `MoveFileEx` with
-`MOVEFILE_REPLACE_EXISTING`, or `ReplaceFile` where its additional semantics are wanted, via
-`golang.org/x/sys/windows`. Both are atomic on NTFS. Section 3.16 already anticipated this as a
-future refinement; multi-bridge support is what makes it mandatory.
+The bridge must therefore use a genuinely atomic replace: `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING`, or `ReplaceFile` where its additional semantics are wanted, via `golang.org/x/sys/windows`. Both are atomic on NTFS. Section 3.16 already anticipated this as a future refinement; multi-bridge support is what makes it mandatory.
 
 #### 3.25.7 Temp File Naming and the Startup Sweeper
 
@@ -1986,46 +1510,21 @@ Temp file names gain the client id:
 <name>.md.tmp.<client-id>.<random>
 ```
 
-The startup sweeper deletes only orphan temp files carrying **its own** client id and older than
-the existing age threshold. A peer's in-flight temp file is neither matched nor removed. Temp files
-belonging to a client that is no longer deployed persist harmlessly until that client next starts;
-they are small, and deleting a peer's file cannot be made safe without a liveness check the lock
-design deliberately avoids.
+The startup sweeper deletes only orphan temp files carrying **its own** client id and older than the existing age threshold. A peer's in-flight temp file is neither matched nor removed. Temp files belonging to a client that is no longer deployed persist harmlessly until that client next starts; they are small, and deleting a peer's file cannot be made safe without a liveness check the lock design deliberately avoids.
 
 #### 3.25.8 Effect on Branching and Merging
 
-Branching needs no algorithmic change. This is the payoff from
-[Section 3.25.1](#3251-what-the-existing-design-already-gets-right): the branch/no-branch decision
-was already made against on-disk state, so restoring atomicity around it — via the cross-process
-lock — plus strengthening the signature is sufficient to make it correct across bridges. The branch
-map, the naming convention, read-your-own-writes, and the no-branches-of-branches rule all carry
-over verbatim.
+Branching needs no algorithmic change. This is the payoff from [Section 3.25.1](#3251-what-the-existing-design-already-gets-right): the branch/no-branch decision was already made against on-disk state, so restoring atomicity around it — via the cross-process lock — plus strengthening the signature is sufficient to make it correct across bridges. The branch map, the naming convention, read-your-own-writes, and the no-branches-of-branches rule all carry over verbatim.
 
-Merging requires one genuine addition. Step 7 of [Section 3.17](#317-merge-process-and-merge-mutex)
-clears branch-map entries `(*, B)` so that every handle routes back to the merged base. A bridge
-can do that for its own handles, but it **cannot** write a peer's state file, so a peer's handles
-would retain branch-map entries pointing at files the merge has deleted.
+Merging requires one genuine addition. Step 7 of [Section 3.17](#317-merge-process-and-merge-mutex) clears branch-map entries `(*, B)` so that every handle routes back to the merged base. A bridge can do that for its own handles, but it **cannot** write a peer's state file, so a peer's handles would retain branch-map entries pointing at files the merge has deleted.
 
-The fix is to make branch-map entries **self-healing at routing time** rather than requiring the
-merging bridge to reach into peer state. The read and write routing rules of
-[Section 3.15](#315-per-handle-branching-and-race-detection) gain a precondition:
+The fix is to make branch-map entries **self-healing at routing time** rather than requiring the merging bridge to reach into peer state. The read and write routing rules of [Section 3.15](#315-per-handle-branching-and-race-detection) gain a precondition:
 
-> If the branch map has an entry for `(H, B)` but the referenced branch file no longer exists,
-> the branch was merged away by a peer. Drop the entry, fall back to the base file, and reset
-> `H`'s baseline for `B` on the next read.
+> If the branch map has an entry for `(H, B)` but the referenced branch file no longer exists, the branch was merged away by a peer. Drop the entry, fall back to the base file, and reset `H`'s baseline for `B` on the next read.
 
-This keeps every bridge the sole writer of its own state while guaranteeing that a merge performed
-anywhere becomes visible everywhere, on next use, with no coordination. It also subsumes the
-startup reconcile step (item 2 of [Section 3.25.4](#3254-per-client-state-files)) as a runtime
-invariant rather than a startup-only sweep, which is strictly stronger.
+This keeps every bridge the sole writer of its own state while guaranteeing that a merge performed anywhere becomes visible everywhere, on next use, with no coordination. It also subsumes the startup reconcile step (item 2 of [Section 3.25.4](#3254-per-client-state-files)) as a runtime invariant rather than a startup-only sweep, which is strictly stronger.
 
-**Expected frequency, revised.** [Section 3.15](#315-per-handle-branching-and-race-detection) notes
-that the typical one-conversation-at-a-time pattern produces zero branches. With two clients in
-regular use — particularly Claude Code, where long agentic sessions may run while a Desktop
-conversation is also active — simultaneous conversations become common rather than exceptional.
-Branching should be expected to occur in normal operation, and the merge path becomes a routine
-code path rather than a rarely-exercised one. It must be tested accordingly
-([Chapter 8](stateful-agent-design-chapter8.md#8-testing-strategy)).
+**Expected frequency, revised.** [Section 3.15](#315-per-handle-branching-and-race-detection) notes that the typical one-conversation-at-a-time pattern produces zero branches. With two clients in regular use — particularly Claude Code, where long agentic sessions may run while a Desktop conversation is also active — simultaneous conversations become common rather than exceptional. Branching should be expected to occur in normal operation, and the merge path becomes a routine code path rather than a rarely-exercised one. It must be tested accordingly ([Chapter 8](stateful-agent-design-chapter8.md#8-testing-strategy)).
 
 #### 3.25.9 Configuration Summary
 

--- a/docs/stateful-agent-design/stateful-agent-design-chapter5.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter5.md
@@ -23,10 +23,7 @@ The memory-aware tool redesign makes this the most-simplified chapter of the des
 
 ### 5.1 Skill Packaging
 
-The memory skill is installed in one of two ways, depending on the client
-([Chapter 7](stateful-agent-design-chapter7.md#7-build-and-deployment)). Claude Code reads skills
-directly from the filesystem, so installation there is a file copy and the packaging rules below
-do not apply. Claude Desktop takes an uploaded archive, described here.
+The memory skill is installed in one of two ways, depending on the client ([Chapter 7](stateful-agent-design-chapter7.md#7-build-and-deployment)). Claude Code reads skills directly from the filesystem, so installation there is a file copy and the packaging rules below do not apply. Claude Desktop takes an uploaded archive, described here.
 
 The memory skill is a Claude Desktop skill packaged as a `.zip` file. Claude Desktop's uploader expects the archive to contain a single top-level *folder* whose name matches the skill's `name`, with `SKILL.md` inside it — not a bare `SKILL.md` at the archive root (a mismatched or missing folder is a documented upload-failure cause). The skill contains no scripts (all operations use the bridge's MCP tools). Upload it via Claude Desktop > Customize > Skills > "+" > "Upload a skill". Keep the `.zip` extension; `.skill` is only the extension Claude Desktop produces when you *download* an existing skill.
 
@@ -173,9 +170,7 @@ spawn_agent(
 
 ### 5.7 Frontmatter Constraints and Portability
 
-The `description` field is subject to **three different documented limits**, depending on how the
-skill reaches the agent. Getting this wrong is a silent failure, so the constraints are recorded
-here rather than left to be rediscovered.
+The `description` field is subject to **three different documented limits**, depending on how the skill reaches the agent. Getting this wrong is a silent failure, so the constraints are recorded here rather than left to be rediscovered.
 
 | Surface | `name` | `description` | Nature of the limit |
 |---|---|---|---|
@@ -185,90 +180,32 @@ here rather than left to be rediscovered.
 
 **Design decision: the `description` targets 200 characters or fewer.**
 
-The reasoning is that 200 is the tightest documented ceiling among the surfaces this system may
-plausibly be delivered through, and a description authored to the 1024-character specification
-limit cannot be uploaded through the Claude.ai Skills UI without being edited first. Since the
-Stateful Agent system may eventually be packaged for general release rather than remaining a
-personal deployment, the skill must install unmodified on every surface. Designing to the tightest
-ceiling costs a little expressiveness once; designing to the loosest costs a manual edit on every
-constrained install, forever.
+The reasoning is that 200 is the tightest documented ceiling among the surfaces this system may plausibly be delivered through, and a description authored to the 1024-character specification limit cannot be uploaded through the Claude.ai Skills UI without being edited first. Since the Stateful Agent system may eventually be packaged for general release rather than remaining a personal deployment, the skill must install unmodified on every surface. Designing to the tightest ceiling costs a little expressiveness once; designing to the loosest costs a manual edit on every constrained install, forever.
 
-**On enforcement.** In July 2026 the 570-character `description` this design previously specified
-was observed reaching a Claude.ai session's skill listing fully intact, so the 200-character limit
-is evidently not enforced uniformly on every upload path today. That observation is deliberately
-*not* treated as license to exceed it. Non-enforcement is not a contract: it can be tightened at
-any time, and — see below — the failure it would produce is invisible.
+**On enforcement.** In July 2026 the 570-character `description` this design previously specified was observed reaching a Claude.ai session's skill listing fully intact, so the 200-character limit is evidently not enforced uniformly on every upload path today. That observation is deliberately *not* treated as license to exceed it. Non-enforcement is not a contract: it can be tightened at any time, and — see below — the failure it would produce is invisible.
 
-**Why truncation is the dangerous failure mode.** A description that exceeds a limit is not
-rejected with an error the author will notice; it is silently cut, from the end. The trailing
-content of a description is where "and use it when…" trigger vocabulary conventionally sits, so
-truncation removes precisely the part that governs invocation while leaving the skill visibly
-installed and apparently healthy. The skill simply stops being selected in cases it used to cover,
-with nothing anywhere reporting why. Two consequences follow:
+**Why truncation is the dangerous failure mode.** A description that exceeds a limit is not rejected with an error the author will notice; it is silently cut, from the end. The trailing content of a description is where "and use it when…" trigger vocabulary conventionally sits, so truncation removes precisely the part that governs invocation while leaving the skill visibly installed and apparently healthy. The skill simply stops being selected in cases it used to cover, with nothing anywhere reporting why. Two consequences follow:
 
-1. **Front-load the triggers.** The earliest words must carry the conditions under which the skill
-   applies, so that any truncation removes elaboration rather than meaning.
-2. **Prefer trigger coverage to elegance.** Within the budget, spend characters on the vocabulary a
-   request is likely to use, not on describing the mechanism. The mechanism is what the body is
-   for.
+1. **Front-load the triggers.** The earliest words must carry the conditions under which the skill applies, so that any truncation removes elaboration rather than meaning.
+2. **Prefer trigger coverage to elegance.** Within the budget, spend characters on the vocabulary a request is likely to use, not on describing the mechanism. The mechanism is what the body is for.
 
-**Known limitation.** The frontmatter `description` is metadata consulted to decide whether a skill
-is *relevant*, which is not the same as an instruction that is reliably *executed*. A conversation
-in which the skill's start-of-conversation directive was present in the description but
-`memory_start_conversation` was nonetheless never called has been observed. Shortening the
-description neither causes nor cures this; the reliability of start-of-conversation initialization
-is tracked separately as an open question
-([Chapter 11](stateful-agent-design-chapter11.md#11-open-questions)) and is out of scope for this
-section, which governs only the field's length and content.
+**Known limitation.** The frontmatter `description` is metadata consulted to decide whether a skill is *relevant*, which is not the same as an instruction that is reliably *executed*. A conversation in which the skill's start-of-conversation directive was present in the description but `memory_start_conversation` was nonetheless never called has been observed. Shortening the description neither causes nor cures this; the reliability of start-of-conversation initialization is tracked separately as an open question ([Chapter 11](stateful-agent-design-chapter11.md#11-open-questions)) and is out of scope for this section, which governs only the field's length and content.
 
 ### 5.8 Bootstrapping via an Unconditionally-Loaded Channel
 
-[Section 5.7](#57-frontmatter-constraints-and-portability) established that the skill `description`
-is metadata used to decide whether a skill is *relevant*, not a mechanism that guarantees an
-instruction is *executed* — and OQ#18
-([Chapter 11](stateful-agent-design-chapter11.md#111-remaining-open-questions)) records a real
-conversation in which the description was present in the skill listing and
-`memory_start_conversation` was nonetheless never called. Relying on the description alone to make
-the agent bootstrap memory is therefore unreliable by construction: the directive that governs the
-single most important action in the whole system — the mandatory first call that loads `core.md`
-and the block index — lives in a field whose job is discovery, and it is only elaborated in the
-skill body once the skill has already been judged relevant.
+[Section 5.7](#57-frontmatter-constraints-and-portability) established that the skill `description` is metadata used to decide whether a skill is *relevant*, not a mechanism that guarantees an instruction is *executed* — and OQ#18 ([Chapter 11](stateful-agent-design-chapter11.md#111-remaining-open-questions)) records a real conversation in which the description was present in the skill listing and `memory_start_conversation` was nonetheless never called. Relying on the description alone to make the agent bootstrap memory is therefore unreliable by construction: the directive that governs the single most important action in the whole system — the mandatory first call that loads `core.md` and the block index — lives in a field whose job is discovery, and it is only elaborated in the skill body once the skill has already been judged relevant.
 
-**The resolution is to place the bootstrap directive additionally in a channel that is loaded
-verbatim into every conversation, with no relevance gating.** This does not replace the skill: the
-skill's conversation-start protocol ([Section 5.3](#53-conversation-lifecycle)) and its description
-remain exactly as specified, the description continuing to do the discovery job it does well. What
-changes is that *execution reliability no longer depends on relevance matching* — the unconditional
-channel carries the imperative, and the skill carries the detail. The two reinforce each other; the
-belt does not need the suspenders to be present, but both cost little and the failure mode being
-guarded against is silent.
+**The resolution is to place the bootstrap directive additionally in a channel that is loaded verbatim into every conversation, with no relevance gating.** This does not replace the skill: the skill's conversation-start protocol ([Section 5.3](#53-conversation-lifecycle)) and its description remain exactly as specified, the description continuing to do the discovery job it does well. What changes is that *execution reliability no longer depends on relevance matching* — the unconditional channel carries the imperative, and the skill carries the detail. The two reinforce each other; the belt does not need the suspenders to be present, but both cost little and the failure mode being guarded against is silent.
 
 Each client has such a channel:
 
-- **Claude Desktop:** the user's preferences (Settings → Profile personalization), which are loaded
-  into every conversation. The wording below belongs there. (This is the same mechanism that already
-  reliably steers other cross-conversation behavior in this deployment, such as the GitHub and
-  Bluesky conventions.)
-- **Claude Code:** the auto-loaded `CLAUDE.md`. The wording, and an important sub-agent-safety
-  caveat, are given in [Section 6.5](stateful-agent-design-chapter6.md#65-claudemd-recommendations).
+- **Claude Desktop:** the user's preferences (Settings → Profile personalization), which are loaded into every conversation. The wording below belongs there. (This is the same mechanism that already reliably steers other cross-conversation behavior in this deployment, such as the GitHub and Bluesky conventions.)
+- **Claude Code:** the auto-loaded `CLAUDE.md`. The wording, and an important sub-agent-safety caveat, are given in [Section 6.5](stateful-agent-design-chapter6.md#65-claudemd-recommendations).
 
 **Proposed Claude Desktop user-preferences wording:**
 
-> At the start of every conversation, before doing anything else, call `memory_start_conversation`
-> to load my stored memory. It returns a handle together with my core memory and the block index;
-> use that handle on every subsequent memory tool call. If any memory tool reports an unknown or
-> invalid handle, call `memory_start_conversation` again to obtain a fresh handle and retry. This is
-> the only way to mint a handle — there is no other initialization path.
+> At the start of every conversation, before doing anything else, call `memory_start_conversation` to load my stored memory. It returns a handle together with my core memory and the block index; use that handle on every subsequent memory tool call. If any memory tool reports an unknown or invalid handle, call `memory_start_conversation` again to obtain a fresh handle and retry. This is the only way to mint a handle — there is no other initialization path.
 
-The final sentence is deliberate: it reflects the reaffirmed decision
-([Chapter 3, Sections 3.3/3.14](stateful-agent-design-chapter3.md#314-handle-management)) that
-`memory_start_conversation` is the *sole* handle-minting mechanism and that the bridge performs no
-auto-initialization. Stating that plainly in the channel the agent actually reads removes any
-temptation to expect a handle to appear by some other means, and it makes the uniform error-recovery
-procedure ("get a new handle, retry") the obvious response to any handle error.
+The final sentence is deliberate: it reflects the reaffirmed decision ([Chapter 3, Sections 3.3/3.14](stateful-agent-design-chapter3.md#314-handle-management)) that `memory_start_conversation` is the *sole* handle-minting mechanism and that the bridge performs no auto-initialization. Stating that plainly in the channel the agent actually reads removes any temptation to expect a handle to appear by some other means, and it makes the uniform error-recovery procedure ("get a new handle, retry") the obvious response to any handle error.
 
-**What this section does not do.** It does not weaken or bypass the mandatory-first-call invariant;
-it strengthens the odds that the invariant is honored by putting the instruction where it will be
-read every time. And it does not make initialization automatic — an agent that ignores both the
-unconditional channel and the skill still fails to bootstrap, and that residual case is exactly what
-OQ#18 leaves open pending measurement (see [Chapter 8, Section 8.2.8](stateful-agent-design-chapter8.md#828-compliance-monitoring-script)).
+**What this section does not do.** It does not weaken or bypass the mandatory-first-call invariant; it strengthens the odds that the invariant is honored by putting the instruction where it will be read every time. And it does not make initialization automatic — an agent that ignores both the unconditional channel and the skill still fails to bootstrap, and that residual case is exactly what OQ#18 leaves open pending measurement (see [Chapter 8, Section 8.2.8](stateful-agent-design-chapter8.md#828-compliance-monitoring-script)).

--- a/docs/stateful-agent-design/stateful-agent-design-chapter6.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter6.md
@@ -102,9 +102,7 @@ The file `C:\Users\flitt\.claude\CLAUDE.md` is loaded into every Claude Code inv
 - OS environment (Windows 11 + Cygwin, shell behavior, pathname conventions)
 - Available tools (compilers, package managers, utilities)
 - Source code conventions (line width, comments, encoding, newlines)
-- Memory bootstrap — the mandatory `memory_start_conversation` call at conversation start
-  (see the sub-agent-safety note below). This is session-core behavior, not a service-specific
-  instruction, so it is not excluded by the "should NOT include" rule that follows.
+- Memory bootstrap — the mandatory `memory_start_conversation` call at conversation start (see the sub-agent-safety note below). This is session-core behavior, not a service-specific instruction, so it is not excluded by the "should NOT include" rule that follows.
 
 **Should NOT include:**
 - Credentials (API tokens, passwords — use environment variables instead)
@@ -165,20 +163,9 @@ Recommended `CLAUDE.md` content:
   do nothing for it.
 ```
 
-**Sub-agent safety of the memory-bootstrap block.** The `CLAUDE.md` above is loaded into *every*
-Claude Code invocation, including sub-agents, and sub-agents do not inherit the parent session's MCP
-connections ([Section 7.8](stateful-agent-design-chapter7.md#78-claude-code-deployment)) — so a
-sub-agent has no memory tools. The block is therefore written as a **conditional guarded on tool
-availability**: the primary agent, which has the memory tools, acts on it; a sub-agent, which does
-not, treats it as inert. Without that guard the instruction would tell every sub-agent to call a
-tool it cannot reach, producing a guaranteed failed call at the top of every sub-agent run. The
-guard is the reason the directive is phrased "if the memory tools are available" rather than as a
-bare imperative. This is consistent with [Section 6.6](#66-sub-agent-memory-access-rules): sub-agents
-receive no Layer 2 write access, and here they correctly receive no bootstrap obligation either.
+**Sub-agent safety of the memory-bootstrap block.** The `CLAUDE.md` above is loaded into *every* Claude Code invocation, including sub-agents, and sub-agents do not inherit the parent session's MCP connections ([Section 7.8](stateful-agent-design-chapter7.md#78-claude-code-deployment)) — so a sub-agent has no memory tools. The block is therefore written as a **conditional guarded on tool availability**: the primary agent, which has the memory tools, acts on it; a sub-agent, which does not, treats it as inert. Without that guard the instruction would tell every sub-agent to call a tool it cannot reach, producing a guaranteed failed call at the top of every sub-agent run. The guard is the reason the directive is phrased "if the memory tools are available" rather than as a bare imperative. This is consistent with [Section 6.6](#66-sub-agent-memory-access-rules): sub-agents receive no Layer 2 write access, and here they correctly receive no bootstrap obligation either.
 
-The token cost of the block is small (well under 100 tokens), so it does not threaten the target
-size above. The rationale for placing it here at all — rather than relying on the skill description —
-is given in [Chapter 5, Section 5.8](stateful-agent-design-chapter5.md#58-bootstrapping-via-an-unconditionally-loaded-channel).
+The token cost of the block is small (well under 100 tokens), so it does not threaten the target size above. The rationale for placing it here at all — rather than relying on the skill description — is given in [Chapter 5, Section 5.8](stateful-agent-design-chapter5.md#58-bootstrapping-via-an-unconditionally-loaded-channel).
 
 ### 6.6 Sub-Agent Memory Access Rules
 

--- a/docs/stateful-agent-design/stateful-agent-design-chapter7.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter7.md
@@ -68,10 +68,7 @@ Add the bridge server entry:
 
 The Desktop App will launch the bridge as a subprocess on startup, communicating via stdio.
 
-If any other MCP client will also run the bridge against the same memory root, add
-`"--client-id", "desktop"` to `args` — see [Section 7.9](#79-running-multiple-clients-concurrently)
-and [Chapter 3, Section 3.25.4](stateful-agent-design-chapter3.md#3254-per-client-state-files). The
-value defaults to `desktop`, so a Desktop-only deployment may omit it.
+If any other MCP client will also run the bridge against the same memory root, add `"--client-id", "desktop"` to `args` — see [Section 7.9](#79-running-multiple-clients-concurrently) and [Chapter 3, Section 3.25.4](stateful-agent-design-chapter3.md#3254-per-client-state-files). The value defaults to `desktop`, so a Desktop-only deployment may omit it.
 
 **Note:** The Filesystem extension does **not** appear in `claude_desktop_config.json` and should **not** be added there. It is a first-party Claude Desktop extension developed by Anthropic and distributed through Claude Desktop's built-in extensions gallery (Settings > Extensions). It is installed, enabled, and configured entirely through the Claude Desktop UI — not via the config JSON file. Claude Desktop manages its configuration for first-party extensions through a separate internal store. See the resolution of Open Question #6 for details.
 
@@ -124,17 +121,9 @@ Replace the current `C:\Users\flitt\.claude\CLAUDE.md` with the lean sub-agent-o
 
 ### 7.8 Claude Code Deployment
 
-Claude Code is a supported client alongside Claude Desktop. It acts as an MCP client over the same
-stdio transport, so **the bridge binary requires no changes** to run under it; what differs is
-registration, skill installation, and the concurrency configuration of
-[Section 7.9](#79-running-multiple-clients-concurrently).
+Claude Code is a supported client alongside Claude Desktop. It acts as an MCP client over the same stdio transport, so **the bridge binary requires no changes** to run under it; what differs is registration, skill installation, and the concurrency configuration of [Section 7.9](#79-running-multiple-clients-concurrently).
 
-**Register the bridge.** Claude Code stores MCP server configuration at three scopes: `local`
-(private to you, tied to one project), `project` (`.mcp.json` at the repository root, intended to
-be committed and shared), and `user` (global across all your projects). Memory is a personal,
-cross-project facility, so `user` scope is the correct choice — a project-scoped registration would
-make memory available only inside one repository, and a committed `.mcp.json` would publish a
-machine-specific absolute path:
+**Register the bridge.** Claude Code stores MCP server configuration at three scopes: `local` (private to you, tied to one project), `project` (`.mcp.json` at the repository root, intended to be committed and shared), and `user` (global across all your projects). Memory is a personal, cross-project facility, so `user` scope is the correct choice — a project-scoped registration would make memory available only inside one repository, and a committed `.mcp.json` would publish a machine-specific absolute path:
 
 ```bash
 claude mcp add --transport stdio --scope user mcp-bridge \
@@ -143,71 +132,34 @@ claude mcp add --transport stdio --scope user mcp-bridge \
      --client-id claude-code
 ```
 
-The `--` separates Claude Code's own flags from the command line handed to the server. User-scope
-registration is written to `~/.claude.json`; note that this file is per-machine and is not
-synchronized across machines, so the command must be run once on each machine where the bridge is
-deployed.
+The `--` separates Claude Code's own flags from the command line handed to the server. User-scope registration is written to `~/.claude.json`; note that this file is per-machine and is not synchronized across machines, so the command must be run once on each machine where the bridge is deployed.
 
 Verify with `claude mcp list`, or `/mcp` inside a session, which also reports connection status.
 
-**Install the skill.** Claude Code reads skills from the filesystem rather than from an uploaded
-archive, so there is no zip step and no upload step:
+**Install the skill.** Claude Code reads skills from the filesystem rather than from an uploaded archive, so there is no zip step and no upload step:
 
 ```bash
 mkdir -p ~/.claude/skills/stateful-memory
 cp SKILL.md ~/.claude/skills/stateful-memory/
 ```
 
-The directory name must match the skill's `name` frontmatter field (`stateful-memory`). The same
-`SKILL.md` taken from the bridge repository per [Chapter 5, Section 5.2](stateful-agent-design-chapter5.md#52-skillmd-content)
-is used verbatim for both clients — this is the practical payoff of holding the `description` to
-the tightest documented limit ([Section 5.7](stateful-agent-design-chapter5.md#57-frontmatter-constraints-and-portability)):
-one artifact, no per-client variants to keep in sync.
+The directory name must match the skill's `name` frontmatter field (`stateful-memory`). The same `SKILL.md` taken from the bridge repository per [Chapter 5, Section 5.2](stateful-agent-design-chapter5.md#52-skillmd-content) is used verbatim for both clients — this is the practical payoff of holding the `description` to the tightest documented limit ([Section 5.7](stateful-agent-design-chapter5.md#57-frontmatter-constraints-and-portability)): one artifact, no per-client variants to keep in sync.
 
 **Two behavioral differences worth knowing.**
 
-- **Tool definitions may be deferred.** Claude Code enables tool search by default, which defers
-  MCP tool definitions so that registering additional servers costs little context. A deferred tool
-  is not directly callable until it has been searched for, which weakens the affordance to invoke a
-  memory tool spontaneously. This interacts with the initialization-reliability question recorded
-  as OQ#18 ([Chapter 11](stateful-agent-design-chapter11.md#111-remaining-open-questions)).
-- **Sub-agents cannot reach the bridge.** Claude Code sub-agents do not inherit the parent session's
-  MCP server connections, so a sub-agent spawned by Claude Code has no memory access. This is
-  consistent with — and independently enforces — the design's existing rule that sub-agents never
-  write to memory ([Chapter 6, Section 6.6](stateful-agent-design-chapter6.md#66-sub-agent-memory-access-rules)),
-  but it also means sub-agents cannot *read* memory under Claude Code, so any context a sub-agent
-  needs must be passed explicitly in its prompt.
+- **Tool definitions may be deferred.** Claude Code enables tool search by default, which defers MCP tool definitions so that registering additional servers costs little context. A deferred tool is not directly callable until it has been searched for, which weakens the affordance to invoke a memory tool spontaneously. This interacts with the initialization-reliability question recorded as OQ#18 ([Chapter 11](stateful-agent-design-chapter11.md#111-remaining-open-questions)).
+- **Sub-agents cannot reach the bridge.** Claude Code sub-agents do not inherit the parent session's MCP server connections, so a sub-agent spawned by Claude Code has no memory access. This is consistent with — and independently enforces — the design's existing rule that sub-agents never write to memory ([Chapter 6, Section 6.6](stateful-agent-design-chapter6.md#66-sub-agent-memory-access-rules)), but it also means sub-agents cannot *read* memory under Claude Code, so any context a sub-agent needs must be passed explicitly in its prompt.
 
 ### 7.9 Running Multiple Clients Concurrently
 
-Each MCP client spawns its own instance of the bridge binary. Deploying both Claude Desktop and
-Claude Code therefore means two bridge processes sharing one memory root, which requires the
-multi-bridge provisions of
-[Chapter 3, Section 3.25](stateful-agent-design-chapter3.md#325-multi-bridge-concurrency).
+Each MCP client spawns its own instance of the bridge binary. Deploying both Claude Desktop and Claude Code therefore means two bridge processes sharing one memory root, which requires the multi-bridge provisions of [Chapter 3, Section 3.25](stateful-agent-design-chapter3.md#325-multi-bridge-concurrency).
 
 Deployment requirements:
 
-1. **Every client must pass a distinct, stable `--client-id`.** Two clients sharing an id will
-   overwrite each other's state file; a client whose id changes between launches will orphan its
-   own handles, branch map, and read baselines on every restart. Use `desktop` and `claude-code`.
-2. **All clients must point at the same memory root**, via the same `bridge-config.yaml` or
-   equivalent configuration. Two bridges with different memory roots are simply two independent
-   memory systems, which is a supported configuration but not a shared one.
-3. **All clients should run the same bridge build.** The cross-process lock, the state-file naming
-   convention, the temp-file naming convention, and the signature format are all shared on-disk
-   contracts. A mixed-version deployment where one bridge predates
-   [Section 3.25](stateful-agent-design-chapter3.md#325-multi-bridge-concurrency) provides *no*
-   safety at all, because the older binary takes no lock — the newer one would be serializing
-   against a peer that ignores serialization entirely.
+1. **Every client must pass a distinct, stable `--client-id`.** Two clients sharing an id will overwrite each other's state file; a client whose id changes between launches will orphan its own handles, branch map, and read baselines on every restart. Use `desktop` and `claude-code`.
+2. **All clients must point at the same memory root**, via the same `bridge-config.yaml` or equivalent configuration. Two bridges with different memory roots are simply two independent memory systems, which is a supported configuration but not a shared one.
+3. **All clients should run the same bridge build.** The cross-process lock, the state-file naming convention, the temp-file naming convention, and the signature format are all shared on-disk contracts. A mixed-version deployment where one bridge predates [Section 3.25](stateful-agent-design-chapter3.md#325-multi-bridge-concurrency) provides *no* safety at all, because the older binary takes no lock — the newer one would be serializing against a peer that ignores serialization entirely.
 
-**Migration from a single-client deployment.** No manual step is required. On first startup the
-bridge renames an existing `.bridge-state.json` to `.bridge-state-<client-id>.json`
-([Chapter 3, Section 3.25.4](stateful-agent-design-chapter3.md#3254-per-client-state-files)).
-Perform this first startup with the Desktop client (or whichever client owns the existing state)
-before registering the second client, so the legacy state is attributed to the right one.
+**Migration from a single-client deployment.** No manual step is required. On first startup the bridge renames an existing `.bridge-state.json` to `.bridge-state-<client-id>.json` ([Chapter 3, Section 3.25.4](stateful-agent-design-chapter3.md#3254-per-client-state-files)). Perform this first startup with the Desktop client (or whichever client owns the existing state) before registering the second client, so the legacy state is attributed to the right one.
 
-**Expect branches.** With one client, simultaneous conversations were the exception and branching
-was effectively never triggered. With two clients — especially given that Claude Code sessions can
-run for a long time while a Desktop conversation is also active — concurrent modification becomes
-ordinary. `memory_run_maintenance` moves from a rarely-needed housekeeping call to a routine part
-of the workflow, and should be run correspondingly more often.
+**Expect branches.** With one client, simultaneous conversations were the exception and branching was effectively never triggered. With two clients — especially given that Claude Code sessions can run for a long time while a Desktop conversation is also active — concurrent modification becomes ordinary. `memory_run_maintenance` moves from a rarely-needed housekeeping call to a routine part of the workflow, and should be run correspondingly more often.

--- a/docs/stateful-agent-design/stateful-agent-design-chapter9.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter9.md
@@ -48,17 +48,13 @@ C:\franl\.claude-agent-memory\
 
 Also investigate semantic memory storage and search technologies such as:
 
-- [engram](https://github.com/mirrorfields/engram)\
-  *Memories are stored in SQLite alongside their vector embeddings and a full-text search index. Search combines cosine similarity (via sqlite-vec) with keyword matching (via FTS5), merged using reciprocal rank fusion — so you get both semantic understanding and exact-term recall. Collections are just string namespaces. Existing memories are migrated into the FTS index automatically on first run.*
+- [engram](https://github.com/mirrorfields/engram)\ *Memories are stored in SQLite alongside their vector embeddings and a full-text search index. Search combines cosine similarity (via sqlite-vec) with keyword matching (via FTS5), merged using reciprocal rank fusion — so you get both semantic understanding and exact-term recall. Collections are just string namespaces. Existing memories are migrated into the FTS index automatically on first run.*
 
-- [MCP Memory Service](https://github.com/doobidoo/mcp-memory-service)\
-  *Probably the most mature and featureful. It's a local MCP server with semantic search (using vector embeddings), a knowledge graph, a web dashboard, and REST API. Works with Claude Desktop, LangGraph, CrewAI, AutoGen, and 13+ other AI clients. Privacy-first / local-first design, optional Cloudflare cloud sync. Written in Python with SQLite-vec for fast local vector storage. Very actively maintained (10.16.x as of recently).*
+- [MCP Memory Service](https://github.com/doobidoo/mcp-memory-service)\ *Probably the most mature and featureful. It's a local MCP server with semantic search (using vector embeddings), a knowledge graph, a web dashboard, and REST API. Works with Claude Desktop, LangGraph, CrewAI, AutoGen, and 13+ other AI clients. Privacy-first / local-first design, optional Cloudflare cloud sync. Written in Python with SQLite-vec for fast local vector storage. Very actively maintained (10.16.x as of recently).*
 
-- [agentic-mcp-tools/memora](https://github.com/agentic-mcp-tools/memora)\
-  *Lightweight local MCP server with semantic memory, knowledge graphs, conversational recall, RAG-powered chat panel, and inter-agent event notifications. Supports both local embeddings (offline, ~2GB PyTorch) and cloud. Works via stdio MCP. Bonus: optional Cloudflare D1 cloud backend. Pretty impressive feature set for its size.*
+- [agentic-mcp-tools/memora](https://github.com/agentic-mcp-tools/memora)\ *Lightweight local MCP server with semantic memory, knowledge graphs, conversational recall, RAG-powered chat panel, and inter-agent event notifications. Supports both local embeddings (offline, ~2GB PyTorch) and cloud. Works via stdio MCP. Bonus: optional Cloudflare D1 cloud backend. Pretty impressive feature set for its size.*
 
-- [tristan-mcinnis/claude-code-agentic-semantic-memory-system-mcp](https://github.com/tristan-mcinnis/claude-code-agentic-semantic-memory-system-mcp)\
-  *Specifically designed for Claude Code. TypeScript MCP server using PostgreSQL + pgvector for semantic search. Supports project namespaces, knowledge graph relations, local embeddings (no external API needed), and intent-based natural language triggers. More opinionated/Claude-specific than the others.*
+- [tristan-mcinnis/claude-code-agentic-semantic-memory-system-mcp](https://github.com/tristan-mcinnis/claude-code-agentic-semantic-memory-system-mcp)\ *Specifically designed for Claude Code. TypeScript MCP server using PostgreSQL + pgvector for semantic search. Supports project namespaces, knowledge graph relations, local embeddings (no external API needed), and intent-based natural language triggers. More opinionated/Claude-specific than the others.*
 
 ### 9.2 Memory-Aware Tools
 


### PR DESCRIPTION
Unwraps the remaining hard-wrapped chapters, following the same treatment applied to Chapter 13 in #57.

## What changed

| File | Lines |
|---|---|
| chapter 3 | 2040 → 1539 |
| chapter 5 | 274 → 211 |
| chapter 6 | 193 → 180 |
| chapter 7 | 213 → 165 |
| chapter 9 | 350 → 346 |

Chapters 4, 8, 11, and 12 were already unwrapped and are untouched.

## No tabs exist

There were none to convert — not in these files, not anywhere in the spec directory. The only files in the repo containing tab bytes are the `.skill` archives, which are packaged binaries.

## Verification

This is whitespace-only, and the risk in a bulk reflow is silent damage, so each file is checked several ways rather than eyeballed:

- **Content preservation.** Before and after are compared with all whitespace collapsed and redundant blockquote markers removed. The script exits without writing if a single word differs.
- **Code fences.** Byte-identical contents and unchanged fence counts per file — 72 fences in chapter 3, 22 in chapter 9, 12 in chapter 7, 10 each in chapters 5 and 6.
- **Tables.** Row counts unchanged (94 in chapter 3, 18 in chapter 9).
- **Hard line breaks.** The two-trailing-space breaks are counted before and after and match exactly; a naive joiner strips them, which is a silent rendering change.
- **Anchors.** Every intra-document link in every chapter resolves against the generated heading slugs.

## Two things the tooling got wrong first, and how

Both were caught by verification rather than by inspection, which is the argument for doing it this way:

1. **Blockquotes were being restyled.** The first run normalized `>Text` to `> Text` throughout chapter 11 — a change to authored markdown that nobody asked for. The joiner now buffers each quote line exactly as written, so marker spacing survives. Chapter 11 is consequently untouched by this PR.
2. **The anchor checker was wrong, not the document.** It initially reported nine broken anchors in chapter 3, all of the form `#310-tool-memory_get_index`. The checker was stripping underscores as emphasis markers; GitHub keeps them in slugs. Running it against the pristine file reproduced the same nine failures, which is what identified it as a checker bug rather than damage. Fixed, and chapter 3 verifies clean both before and after.

## Not included

The main design document (`stateful-agent-design.md`) is still partly wrapped and would change by one line. It is excluded here because #57 also edits it and unwrapping it in parallel would conflict. It should follow once #57 merges.

Also still wrapped, and outside the "every other chapter" scope of this request: `design-review.md`, `design-update-plan.md`, `mcp-bridge-minimal-implementation-prompt.md`, `memory-aware-tools-analysis.md`, `memory-aware-tools-idea.md`, `stateful-agent-proposal.md`, and `claude-code-mcp-usage.md`.