### PR TITLE
Chapter 11: add OQ#27 on entry heading structure in non-episodic blocks

### DIFF
--- a/docs/stateful-agent-design/stateful-agent-design-chapter11.md
+++ b/docs/stateful-agent-design/stateful-agent-design-chapter11.md
@@ -86,6 +86,27 @@ This section contains all questions that were ever open, even if they are now re
 >The existing install script (`deploy/install-bridge.sh` in repo `mcp-bridge`) supports only installing to Claude Desktop Chat. It should be updated to support Claude Code (CLI and Desktop).
 
 *Resolution:* TBD
+
+#### OQ#27: Entry heading structure in non-episodic blocks
+
+>Should `memory_append_block` enforce an entry heading invariant the way `memory_append_episodic` now does? Episodic entries gained a `title` parameter: the bridge renders the heading itself and rejects a `content` body that begins with one, so entry structure in episodic files is an invariant of the storage layer. `memory_append_block` appends its `content` verbatim and imposes nothing, so heading structure in ordinary blocks depends entirely on the calling LLM applying the same convention consistently across separate conversations.
+
+*Resolution:* TBD
+
+The question was raised by an observed failure rather than in the abstract. Appending to `project-stateful-agent-system` across one working session, Claude wrote two consecutive entries at `##` and then, without any prompting or reason, wrote the next five at `###`. The result was that five unrelated entries appeared nested beneath an earlier one in Obsidian's outline panel, which is how Fran noticed. Nothing detected the drift, because nothing was watching: the write path has no notion of what an "entry" is.
+
+Note that this is not a variant of the defect that PR #7 fixed in the episodic path. That defect was a missing newline welding a heading onto the end of a preceding paragraph, and the storage layer could see it. Here every write was individually well-formed; only the *sequence* was inconsistent, and consistency across separate calls is not something a verbatim-append tool is positioned to check.
+
+Three options, with the trade-off being how much structure the storage layer should own versus leave to the writer:
+
+- **Do nothing.** Blocks are free-form by design, unlike the strictly chronological episodic log, and some blocks legitimately want nested headings — the standing sections at the top of `project-stateful-agent-system` (`## Repos and docs`, `## Key architectural decisions`) are not dated entries and a rigid rule would fight them. This option accepts that block structure is the writer's responsibility and treats the drift as a lapse rather than a design gap.
+- **Add an optional `title` parameter** to `memory_append_block`, mirroring `memory_append_episodic` but rendering `## Title` with no date, since block entries are not inherently chronological. When `title` is supplied, the same no-heading-in-`content` guard applies. When it is omitted, behavior is unchanged, so existing callers and free-form appends are unaffected. This makes the convention *available* as an invariant without making it mandatory.
+- **Enforce a maximum heading depth** on appended content — reject any `content` whose first heading is deeper than `##`. This is the strictest option and the one most likely to be wrong, since it would prevent a legitimately nested append.
+
+A prerequisite for any of these is deciding whether "entry" is even a meaningful concept for a non-episodic block, or whether that framing is being imported from the episodic log where it genuinely applies. If blocks are simply documents that get appended to, the second option is the most that is warranted; if blocks are logs with standing preamble sections, a stronger rule may be justified.
+
+This question is related to OQ#20, which asks how older episodic entries should be marked as potentially superseded. Both are ultimately about how much responsibility for entry structure and entry metadata belongs to the bridge rather than to the LLM writing through it, and they may be worth resolving together.
+
 ### 11.2 Resolved Questions
 
 #### OQ#1: Race condition with memory writes


### PR DESCRIPTION
Adds **OQ#27** to §11.1, following the restructured format (blockquote question, italic resolution, prose discussion).

## The question

Should `memory_append_block` enforce an entry heading invariant the way `memory_append_episodic` now does?

The asymmetry is real. Episodic entries gained a `title` parameter, so the bridge renders `## YYYY-MM-DD — Title` itself and rejects a `content` body that begins with a heading — entry structure there is an invariant of the storage layer. `memory_append_block` appends verbatim and imposes nothing, so block heading structure depends entirely on the calling LLM being consistent across separate conversations.

## Why now

Raised by an observed failure, not in the abstract. Appending to `project-stateful-agent-system` across a single session, I wrote two entries at `##` and then five more at `###` for no reason I can reconstruct — each new entry inheriting the depth of my previous write rather than the block's convention. Five unrelated entries ended up nested under an earlier one in Obsidian's outline panel, which is how Fran spotted it.

**This is not a variant of the defect PR #7 fixed.** That was a missing newline welding a heading onto a preceding paragraph — a malformed *single write*, visible to the storage layer. Here every write was individually well-formed and only the *sequence* was inconsistent. A verbatim-append tool has no notion of "entry" and so is not positioned to check it.

## Options recorded

1. **Do nothing.** Blocks are free-form by design, and some legitimately want nested headings — the standing sections at the top of `project-stateful-agent-system` are not dated entries and a rigid rule would fight them.
2. **Optional `title` parameter**, rendering `## Title` with no date (block entries are not inherently chronological), with the no-heading-in-`content` guard applying only when `title` is supplied. Makes the convention available as an invariant without making it mandatory.
3. **Maximum heading depth** on appended content. Strictest, and most likely to be wrong.

The prerequisite question is whether "entry" is even meaningful for a non-episodic block, or whether that framing is being imported from the episodic log where it genuinely applies.

Cross-referenced to **OQ#20**, since both are really about how much responsibility for entry structure and metadata belongs to the bridge rather than the LLM writing through it; they may be worth resolving together.

## Also

Adds the blank line that was missing between OQ#26's resolution line and the `### 11.2` heading.

No other document enumerates the open questions or their count, so nothing outside Chapter 11 needed updating.